### PR TITLE
update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 bin
 target
 secrets
+.bloop
+.metals
+metals.sbt

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import scala.io.Source
 
 implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val kubernetesClient =
   KubernetesClient[IO](
@@ -54,7 +54,7 @@ import scala.concurrent.ExecutionContext
 
 implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val kubernetesClient =
   KubernetesClient[IO](KubeConfig(new File(s"${System.getProperty("user.home")}/.kube/config")))
@@ -76,7 +76,7 @@ import scala.concurrent.ExecutionContext
 
 implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val kubernetesClient =
   KubernetesClient[IO](KubeConfig(new File(s"${System.getProperty("user.home")}/.kube/config")))

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "Kubernetes Client"
 organization := "com.goyeau"
-scalaVersion := "2.12.7"
+scalaVersion := "2.13.1"
 
 libraryDependencies += compilerPlugin(scalafixSemanticdb)
 addCommandAlias("fix", "; compile:scalafix; test:scalafix")
@@ -11,14 +11,12 @@ scalacOptions ++= Seq(
   "-deprecation",
   "-feature",
   "-language:higherKinds",
-  "-Xlint:unsound-match",
-  "-Ywarn-inaccessible",
-  "-Ywarn-infer-any",
+  "-Xlint:inaccessible",
+  "-Xlint:infer-any",
   "-Ywarn-unused:imports",
   "-Ywarn-unused:locals",
   "-Ywarn-unused:patvars",
   "-Ywarn-unused:privates",
-  "-Ypartial-unification",
   "-Ywarn-dead-code"
 )
 enablePlugins(SwaggerModelGenerator)
@@ -37,7 +35,7 @@ Global / releaseEarlyWith := SonatypePublisher
 Global / releaseEarlyEnableLocalReleases := true
 
 lazy val circe = {
-  val circeVersion = "0.10.1"
+  val circeVersion = "0.13.0"
   Seq(
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
@@ -46,7 +44,7 @@ lazy val circe = {
 }
 
 lazy val http4s = {
-  val version = "0.20.0-M3"
+  val version = "0.21.2"
   Seq(
     "org.http4s" %% "http4s-dsl" % version,
     "org.http4s" %% "http4s-circe" % version,
@@ -56,25 +54,25 @@ lazy val http4s = {
 }
 
 lazy val akkaHttp = {
-  val akkaHttpVersion = "10.1.5"
+  val akkaHttpVersion = "10.1.11"
   Seq(
     "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
-    "com.typesafe.akka" %% "akka-stream" % "2.5.17",
+    "com.typesafe.akka" %% "akka-stream" % "2.6.4",
     "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test
   )
 }
 
-lazy val circeYaml = Seq("io.circe" %% "circe-yaml" % "0.9.0")
+lazy val circeYaml = Seq("io.circe" %% "circe-yaml" % "0.12.0")
 
 lazy val bouncycastle = Seq("org.bouncycastle" % "bcpkix-jdk15on" % "1.60")
 
 lazy val logging = Seq(
-  "io.chrisdavenport" %% "log4cats-slf4j" % "0.2.0",
+  "io.chrisdavenport" %% "log4cats-slf4j" % "1.0.1",
   "ch.qos.logback" % "logback-classic" % "1.2.3"
 )
 
 lazy val tests = Seq(
-  "org.scalactic" %% "scalactic" % "3.0.5",
-  "org.scalatest" %% "scalatest" % "3.0.5" % Test,
-  "com.github.julien-truffaut" %% "monocle-core" % "1.5.0-cats" % Test
+  "org.scalactic" %% "scalactic" % "3.1.1",
+  "org.scalatest" %% "scalatest" % "3.1.1" % Test,
+  "com.github.julien-truffaut" %% "monocle-core" % "2.0.4" % Test
 )

--- a/project/SwaggerModelGenerator.scala
+++ b/project/SwaggerModelGenerator.scala
@@ -74,7 +74,7 @@ object SwaggerModelGenerator extends AutoPlugin {
                            |)
                            |
                            |object $className {
-                           |  implicit lazy val encoder: ObjectEncoder[$className] = deriveEncoder
+                           |  implicit lazy val encoder: Encoder.AsObject[$className] = deriveEncoder
                            |  implicit lazy val decoder: Decoder[$className] = deriveDecoder
                            |}
                            |""".stripMargin

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.3.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("io.get-coursier" %% "sbt-coursier" % "1.0.3")
 addSbtPlugin("com.geirsson" %% "sbt-scalafmt" % "1.6.0-RC4")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.13")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1")

--- a/src/main/scala/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/src/main/scala/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -9,7 +9,9 @@ import com.goyeau.kubernetes.client.util.SslContexts
 
 import scala.concurrent.ExecutionContext
 
-case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], config: KubeConfig)(implicit cs: ContextShift[IO]) {
+case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], config: KubeConfig)(
+  implicit cs: ContextShift[IO]
+) {
   lazy val namespaces = NamespacesApi(httpClient, config)
   lazy val pods = PodsApi(httpClient, config)
   lazy val jobs = JobsApi(httpClient, config)
@@ -26,10 +28,14 @@ case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], confi
 }
 
 object KubernetesClient {
-  def apply[F[_]: ConcurrentEffect](config: KubeConfig)(implicit cs: ContextShift[IO]): Resource[F, KubernetesClient[F]] =
+  def apply[F[_]: ConcurrentEffect](
+    config: KubeConfig
+  )(implicit cs: ContextShift[IO]): Resource[F, KubernetesClient[F]] =
     BlazeClientBuilder[F](ExecutionContext.global, Option(SslContexts.fromConfig(config))).resource
       .map(httpClient => apply(httpClient, config))
 
-  def apply[F[_]: ConcurrentEffect](config: F[KubeConfig])(implicit cs: ContextShift[IO]): Resource[F, KubernetesClient[F]] =
+  def apply[F[_]: ConcurrentEffect](
+    config: F[KubeConfig]
+  )(implicit cs: ContextShift[IO]): Resource[F, KubernetesClient[F]] =
     Resource.liftF(config).flatMap(apply(_))
 }

--- a/src/main/scala/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/src/main/scala/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -30,8 +30,6 @@ object KubernetesClient {
     BlazeClientBuilder[F](ExecutionContext.global, Option(SslContexts.fromConfig(config))).resource
       .map(httpClient => apply(httpClient, config))
 
-  def apply[F[_]: ConcurrentEffect](
-    config: F[KubeConfig]
-  )(implicit cs: ContextShift[IO]): Resource[F, KubernetesClient[F]] =
+  def apply[F[_]: ConcurrentEffect](config: F[KubeConfig]): Resource[F, KubernetesClient[F]] =
     Resource.liftF(config).flatMap(apply(_))
 }

--- a/src/main/scala/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/src/main/scala/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -9,7 +9,7 @@ import com.goyeau.kubernetes.client.util.SslContexts
 
 import scala.concurrent.ExecutionContext
 
-case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], config: KubeConfig) {
+case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], config: KubeConfig)(implicit cs: ContextShift[IO]) {
   lazy val namespaces = NamespacesApi(httpClient, config)
   lazy val pods = PodsApi(httpClient, config)
   lazy val jobs = JobsApi(httpClient, config)
@@ -26,10 +26,10 @@ case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], confi
 }
 
 object KubernetesClient {
-  def apply[F[_]: ConcurrentEffect](config: KubeConfig): Resource[F, KubernetesClient[F]] =
+  def apply[F[_]: ConcurrentEffect](config: KubeConfig)(implicit cs: ContextShift[IO]): Resource[F, KubernetesClient[F]] =
     BlazeClientBuilder[F](ExecutionContext.global, Option(SslContexts.fromConfig(config))).resource
       .map(httpClient => apply(httpClient, config))
 
-  def apply[F[_]: ConcurrentEffect](config: F[KubeConfig]): Resource[F, KubernetesClient[F]] =
+  def apply[F[_]: ConcurrentEffect](config: F[KubeConfig])(implicit cs: ContextShift[IO]): Resource[F, KubernetesClient[F]] =
     Resource.liftF(config).flatMap(apply(_))
 }

--- a/src/main/scala/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/src/main/scala/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -9,9 +9,7 @@ import com.goyeau.kubernetes.client.util.SslContexts
 
 import scala.concurrent.ExecutionContext
 
-case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], config: KubeConfig)(
-  implicit cs: ContextShift[IO]
-) {
+case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], config: KubeConfig) {
   lazy val namespaces = NamespacesApi(httpClient, config)
   lazy val pods = PodsApi(httpClient, config)
   lazy val jobs = JobsApi(httpClient, config)
@@ -28,9 +26,7 @@ case class KubernetesClient[F[_]: ConcurrentEffect](httpClient: Client[F], confi
 }
 
 object KubernetesClient {
-  def apply[F[_]: ConcurrentEffect](
-    config: KubeConfig
-  )(implicit cs: ContextShift[IO]): Resource[F, KubernetesClient[F]] =
+  def apply[F[_]: ConcurrentEffect](config: KubeConfig): Resource[F, KubernetesClient[F]] =
     BlazeClientBuilder[F](ExecutionContext.global, Option(SslContexts.fromConfig(config))).resource
       .map(httpClient => apply(httpClient, config))
 

--- a/src/main/scala/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/src/main/scala/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -4,6 +4,7 @@ import java.net.URLEncoder
 
 import scala.concurrent.duration._
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.{ConnectionContext, Http}
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
@@ -12,7 +13,7 @@ import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.stream.scaladsl.BidiFlow
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
-import cats.effect.{Async, ContextShift, IO}
+import cats.effect.Async
 import com.goyeau.kubernetes.client.operation._
 import com.goyeau.kubernetes.client.util.SslContexts
 import com.goyeau.kubernetes.client.{KubeConfig, KubernetesException}
@@ -31,8 +32,7 @@ private[client] case class PodsApi[F[_]](httpClient: Client[F], config: KubeConf
   val F: Async[F],
   val listDecoder: Decoder[PodList],
   encoder: Encoder[Pod],
-  decoder: Decoder[Pod],
-  contextShift: ContextShift[IO]
+  decoder: Decoder[Pod]
 ) extends Listable[F, PodList] {
   val resourceUri = uri("/api") / "v1" / "pods"
 
@@ -48,8 +48,7 @@ private[client] case class NamespacedPodsApi[F[_]](
   val F: Async[F],
   val resourceEncoder: Encoder[Pod],
   val resourceDecoder: Decoder[Pod],
-  val listDecoder: Decoder[PodList],
-  val contextShift: ContextShift[IO]
+  val listDecoder: Decoder[PodList]
 ) extends Creatable[F, Pod]
     with Replaceable[F, Pod]
     with Gettable[F, Pod]
@@ -72,50 +71,54 @@ private[client] case class NamespacedPodsApi[F[_]](
   )(implicit actorSystem: ActorSystem): F[Result] = {
     import actorSystem.dispatcher
 
-    IO.fromFuture(IO {
-        val containerParam = container.fold("")(containerName => s"&container=$containerName")
-        val commandParam = command.map(c => s"&command=${URLEncoder.encode(c, "UTF-8")}").mkString
-        val params = s"stdin=$stdin&stdout=$stdout&stderr=$stderr&tty=$tty$containerParam$commandParam"
-        val uri = s"${config.server.toString.replaceFirst("http", "ws")}/$resourceUri/$podName/exec?$params"
+    F.async { cb =>
+      val containerParam = container.fold("")(containerName => s"&container=$containerName")
+      val commandParam = command.map(c => s"&command=${URLEncoder.encode(c, "UTF-8")}").mkString
+      val params = s"stdin=$stdin&stdout=$stdout&stderr=$stderr&tty=$tty$containerParam$commandParam"
+      val uri = s"${config.server.toString.replaceFirst("http", "ws")}/$resourceUri/$podName/exec?$params"
 
-        val mapFlow = BidiFlow.fromFlows(
-          Flow.fromFunction[Message, Message](identity),
-          Flow
-            .fromFunction[Message, Future[String]] {
-              case BinaryMessage.Strict(data)     => Future.successful(data.utf8String)
-              case BinaryMessage.Streamed(stream) => stream.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
-              case TextMessage.Strict(data)       => Future.successful(data)
-              case TextMessage.Streamed(stream)   => stream.runFold("")(_ + _)
-            }
-            .mapAsync(parallelism = 1)(identity)
-            .map(log => decode[Status](log.trim).fold(_ => Right(log), Left(_)))
-        )
+      val mapFlow = BidiFlow.fromFlows(
+        Flow.fromFunction[Message, Message](identity),
+        Flow
+          .fromFunction[Message, Future[String]] {
+            case BinaryMessage.Strict(data)     => Future.successful(data.utf8String)
+            case BinaryMessage.Streamed(stream) => stream.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
+            case TextMessage.Strict(data)       => Future.successful(data)
+            case TextMessage.Streamed(stream)   => stream.runFold("")(_ + _)
+          }
+          .mapAsync(parallelism = 1)(identity)
+          .map(log => decode[Status](log.trim).fold(_ => Right(log), Left(_)))
+      )
 
-        def convertAuthorization(authorization: http4s.headers.Authorization) = authorization.credentials match {
-          case Token(AuthScheme.Bearer, token) => Authorization(OAuth2BearerToken(token))
-          case _                               => throw new IllegalStateException("")
-        }
+      def convertAuthorization(authorization: http4s.headers.Authorization) = authorization.credentials match {
+        case Token(AuthScheme.Bearer, token) => Authorization(OAuth2BearerToken(token))
+        case _                               => throw new IllegalStateException("")
+      }
 
-        val (upgradeResponse, eventualResult) = Http().singleWebSocketRequest(
-          WebSocketRequest(
-            uri,
-            extraHeaders = config.authorization.toList.map(convertAuthorization),
-            subprotocol = Option("v4.channel.k8s.io")
-          ),
-          flow.join(mapFlow),
-          ConnectionContext.https(SslContexts.fromConfig(config)),
-          settings = ClientConnectionSettings(actorSystem).withIdleTimeout(10.minutes)
-        )
+      val (upgradeResponse, eventualResult) = Http().singleWebSocketRequest(
+        WebSocketRequest(
+          uri,
+          extraHeaders = config.authorization.toList.map(convertAuthorization),
+          subprotocol = Option("v4.channel.k8s.io")
+        ),
+        flow.join(mapFlow),
+        ConnectionContext.https(SslContexts.fromConfig(config)),
+        settings = ClientConnectionSettings(actorSystem).withIdleTimeout(10.minutes)
+      )
 
-        for {
-          upgrade <- upgradeResponse
-          response = upgrade.response
-          entity <- response.entity.dataBytes.runFold(ByteString(""))(_ ++ _)
-          _ = if (response.status.isFailure)
-            throw KubernetesException(response.status.intValue, uri, entity.utf8String)
-          result <- eventualResult
-        } yield result
-      })
-      .to[F]
+      val result = for {
+        upgrade <- upgradeResponse
+        response = upgrade.response
+        entity <- response.entity.dataBytes.runFold(ByteString(""))(_ ++ _)
+        _ = if (response.status.isFailure)
+          throw KubernetesException(response.status.intValue, uri, entity.utf8String)
+        result <- eventualResult
+      } yield result
+
+      result.onComplete {
+        case Success(value) => cb(Right(value))
+        case Failure(error) => cb(Left(error))
+      }
+    }
   }
 }

--- a/src/main/scala/com/goyeau/kubernetes/client/api/SecretsApi.scala
+++ b/src/main/scala/com/goyeau/kubernetes/client/api/SecretsApi.scala
@@ -47,5 +47,5 @@ private[client] case class NamespacedSecretsApi[F[_]](
     createOrUpdate(encode(resource))
 
   private def encode(resource: Secret) =
-    resource.copy(data = resource.data.map(_.mapValues(v => Base64.getEncoder.encodeToString(v.getBytes))))
+    resource.copy(data = resource.data.map(_.view.mapValues(v => Base64.getEncoder.encodeToString(v.getBytes)).toMap))
 }

--- a/src/main/scala/com/goyeau/kubernetes/client/util/CirceEntityCodec.scala
+++ b/src/main/scala/com/goyeau/kubernetes/client/util/CirceEntityCodec.scala
@@ -2,13 +2,12 @@ package com.goyeau.kubernetes.client.util
 
 import cats.Applicative
 import cats.effect.Sync
-import io.circe.{Decoder, Encoder, Json, Printer}
+import io.circe.{Decoder, Encoder, Printer}
 import org.http4s.{EntityDecoder, EntityEncoder}
 import org.http4s.circe.CirceInstances
 
 private[client] object CirceEntityCodec extends CirceInstances {
-  val defaultPrinter: Printer = Printer.noSpaces.copy(dropNullValues = true)
-  def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] = CirceInstances.defaultJsonDecoder
+  override val defaultPrinter: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
   implicit def circeEntityEncoder[F[_]: Applicative, A: Encoder]: EntityEncoder[F, A] = jsonEncoderOf[F, A]
   implicit def circeEntityDecoder[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] = jsonOf[F, A]

--- a/src/main/scala/com/goyeau/kubernetes/client/util/Yamls.scala
+++ b/src/main/scala/com/goyeau/kubernetes/client/util/Yamls.scala
@@ -8,7 +8,7 @@ import com.goyeau.kubernetes.client.KubeConfig
 
 import scala.io.Source
 import io.chrisdavenport.log4cats.Logger
-import io.circe.{Decoder, ObjectEncoder}
+import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto._
 import io.circe.yaml.parser._
 import org.http4s.Uri
@@ -75,20 +75,20 @@ private[client] object Yamls {
       )
 
   implicit lazy val configDecoder: Decoder[Config] = deriveDecoder
-  implicit lazy val configEncoder: ObjectEncoder[Config] = deriveEncoder
+  implicit lazy val configEncoder: Encoder.AsObject[Config] = deriveEncoder
 
   implicit lazy val clusterDecoder: Decoder[Cluster] = deriveDecoder
-  implicit lazy val clusterEncoder: ObjectEncoder[Cluster] = deriveEncoder
+  implicit lazy val clusterEncoder: Encoder.AsObject[Cluster] = deriveEncoder
   implicit lazy val namedClusterDecoder: Decoder[NamedCluster] = deriveDecoder
-  implicit lazy val namedClusterEncoder: ObjectEncoder[NamedCluster] = deriveEncoder
+  implicit lazy val namedClusterEncoder: Encoder.AsObject[NamedCluster] = deriveEncoder
 
   implicit lazy val contextDecoder: Decoder[Context] = deriveDecoder
-  implicit lazy val contextEncoder: ObjectEncoder[Context] = deriveEncoder
+  implicit lazy val contextEncoder: Encoder.AsObject[Context] = deriveEncoder
   implicit lazy val namedContextDecoder: Decoder[NamedContext] = deriveDecoder
-  implicit lazy val namedContextEncoder: ObjectEncoder[NamedContext] = deriveEncoder
+  implicit lazy val namedContextEncoder: Encoder.AsObject[NamedContext] = deriveEncoder
 
   implicit lazy val authInfoDecoder: Decoder[AuthInfo] = deriveDecoder
-  implicit lazy val authInfoEncoder: ObjectEncoder[AuthInfo] = deriveEncoder
+  implicit lazy val authInfoEncoder: Encoder.AsObject[AuthInfo] = deriveEncoder
   implicit lazy val namedAuthInfoDecoder: Decoder[NamedAuthInfo] = deriveDecoder
-  implicit lazy val namedAuthInfoEncoder: ObjectEncoder[NamedAuthInfo] = deriveEncoder
+  implicit lazy val namedAuthInfoEncoder: Encoder.AsObject[NamedAuthInfo] = deriveEncoder
 }

--- a/src/test/scala/com/goyeau/kubernetes/client/api/ConfigMapsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/ConfigMapsApiTest.scala
@@ -7,12 +7,14 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.{ConfigMap, ConfigMapList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class ConfigMapsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, ConfigMap]
@@ -24,7 +26,7 @@ class ConfigMapsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[ConfigMap].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.configMaps

--- a/src/test/scala/com/goyeau/kubernetes/client/api/CronJobsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/CronJobsApiTest.scala
@@ -9,12 +9,14 @@ import io.k8s.api.batch.v1.JobSpec
 import io.k8s.api.batch.v1beta1.{CronJob, CronJobList, CronJobSpec, JobTemplateSpec}
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class CronJobsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, CronJob]
@@ -27,7 +29,7 @@ class CronJobsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[CronJob].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.cronJobs

--- a/src/test/scala/com/goyeau/kubernetes/client/api/DeploymentsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/DeploymentsApiTest.scala
@@ -8,12 +8,14 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.apps.v1._
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class DeploymentsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, Deployment]
@@ -26,7 +28,7 @@ class DeploymentsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[Deployment].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.deployments

--- a/src/test/scala/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
@@ -5,19 +5,16 @@ import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
-import io.k8s.api.autoscaling.v1.{
-  CrossVersionObjectReference,
-  HorizontalPodAutoscaler,
-  HorizontalPodAutoscalerList,
-  HorizontalPodAutoscalerSpec
-}
+import io.k8s.api.autoscaling.v1.{CrossVersionObjectReference, HorizontalPodAutoscaler, HorizontalPodAutoscalerList, HorizontalPodAutoscalerSpec}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class HorizontalPodAutoscalersApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, HorizontalPodAutoscaler]
@@ -29,7 +26,7 @@ class HorizontalPodAutoscalersApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[HorizontalPodAutoscaler].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.horizontalPodAutoscalers

--- a/src/test/scala/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
@@ -5,7 +5,12 @@ import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
-import io.k8s.api.autoscaling.v1.{CrossVersionObjectReference, HorizontalPodAutoscaler, HorizontalPodAutoscalerList, HorizontalPodAutoscalerSpec}
+import io.k8s.api.autoscaling.v1.{
+  CrossVersionObjectReference,
+  HorizontalPodAutoscaler,
+  HorizontalPodAutoscalerList,
+  HorizontalPodAutoscalerSpec
+}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.OptionValues

--- a/src/test/scala/com/goyeau/kubernetes/client/api/JobsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/JobsApiTest.scala
@@ -8,12 +8,14 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.batch.v1.{Job, JobList, JobSpec}
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class JobsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, Job]
@@ -26,7 +28,7 @@ class JobsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[Job].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.jobs

--- a/src/test/scala/com/goyeau/kubernetes/client/api/NamespacesApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/NamespacesApiTest.scala
@@ -11,17 +11,19 @@ import io.k8s.api.core.v1.{Namespace, NamespaceList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.http4s.Status
 import org.http4s.client.UnexpectedStatus
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
-class NamespacesApiTest extends FlatSpec with Matchers with OptionValues with MinikubeClientProvider[IO] {
+class NamespacesApiTest extends AnyFlatSpec with Matchers with OptionValues with MinikubeClientProvider[IO] {
   import NamespacesApiTest._
 
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[Namespace].getSimpleName
 
   "create" should "create a namespace" in usingMinikube { implicit client =>

--- a/src/test/scala/com/goyeau/kubernetes/client/api/PodsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/PodsApiTest.scala
@@ -7,12 +7,14 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.{Container, Pod, PodList, PodSpec}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class PodsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, Pod]
@@ -25,7 +27,7 @@ class PodsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[Pod].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.pods

--- a/src/test/scala/com/goyeau/kubernetes/client/api/ReplicaSetsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/ReplicaSetsApiTest.scala
@@ -8,12 +8,14 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.apps.v1._
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class ReplicaSetsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, ReplicaSet]
@@ -26,7 +28,7 @@ class ReplicaSetsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[ReplicaSet].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.replicaSets

--- a/src/test/scala/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
@@ -104,7 +104,9 @@ class SecretsApiTest
         )
       _ = status shouldBe Status.Ok
       updatedSecret <- getChecked(namespaceName, secretName)
-      _ = updatedSecret.data shouldBe data.map(_.view.mapValues(v => Base64.getEncoder.encodeToString(v.getBytes)).toMap)
+      _ = updatedSecret.data shouldBe data.map(
+        _.view.mapValues(v => Base64.getEncoder.encodeToString(v.getBytes)).toMap
+      )
     } yield ()
   }
 }

--- a/src/test/scala/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
@@ -10,12 +10,14 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.{Secret, SecretList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.http4s.Status
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class SecretsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, Secret]
@@ -27,7 +29,7 @@ class SecretsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[Secret].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.secrets
@@ -102,7 +104,7 @@ class SecretsApiTest
         )
       _ = status shouldBe Status.Ok
       updatedSecret <- getChecked(namespaceName, secretName)
-      _ = updatedSecret.data shouldBe data.map(_.mapValues(v => Base64.getEncoder.encodeToString(v.getBytes)))
+      _ = updatedSecret.data shouldBe data.map(_.view.mapValues(v => Base64.getEncoder.encodeToString(v.getBytes)).toMap)
     } yield ()
   }
 }

--- a/src/test/scala/com/goyeau/kubernetes/client/api/ServiceAccountsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/ServiceAccountsApiTest.scala
@@ -7,12 +7,14 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class ServiceAccountsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, ServiceAccount]
@@ -24,7 +26,7 @@ class ServiceAccountsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[ServiceAccount].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.serviceAccounts

--- a/src/test/scala/com/goyeau/kubernetes/client/api/ServicesApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/ServicesApiTest.scala
@@ -7,12 +7,14 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class ServicesApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, Service]
@@ -24,7 +26,7 @@ class ServicesApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[Service].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.services

--- a/src/test/scala/com/goyeau/kubernetes/client/api/StatefulSetsApiTest.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/api/StatefulSetsApiTest.scala
@@ -8,12 +8,14 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.apps.v1._
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 class StatefulSetsApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with CreatableTests[IO, StatefulSet]
@@ -26,7 +28,7 @@ class StatefulSetsApiTest
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName = classOf[StatefulSet].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.statefulSets

--- a/src/test/scala/com/goyeau/kubernetes/client/operation/CreatableTests.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/operation/CreatableTests.scala
@@ -6,10 +6,12 @@ import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.api.NamespacesApiTest
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.http4s.Status
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 trait CreatableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }]
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with MinikubeClientProvider[F] {

--- a/src/test/scala/com/goyeau/kubernetes/client/operation/DeletableTerminatedTests.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/operation/DeletableTerminatedTests.scala
@@ -6,10 +6,12 @@ import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.api.NamespacesApiTest
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.http4s.Status
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 trait DeletableTerminatedTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }, ResourceList <: { def items: Seq[Resource] }]
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with MinikubeClientProvider[F] {

--- a/src/test/scala/com/goyeau/kubernetes/client/operation/DeletableTests.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/operation/DeletableTests.scala
@@ -6,10 +6,12 @@ import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.api.NamespacesApiTest
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.http4s.Status
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 trait DeletableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }, ResourceList <: { def items: Seq[Resource] }]
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with MinikubeClientProvider[F] {

--- a/src/test/scala/com/goyeau/kubernetes/client/operation/GettableTests.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/operation/GettableTests.scala
@@ -6,12 +6,14 @@ import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.api.NamespacesApiTest
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.http4s.client.UnexpectedStatus
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.language.reflectiveCalls
 
 trait GettableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }]
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with MinikubeClientProvider[F] {

--- a/src/test/scala/com/goyeau/kubernetes/client/operation/ListableTests.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/operation/ListableTests.scala
@@ -4,12 +4,14 @@ import cats.Applicative
 import cats.implicits._
 import com.goyeau.kubernetes.client.KubernetesClient
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 import scala.language.reflectiveCalls
 
 trait ListableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }, ResourceList <: { def items: Seq[Resource] }]
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with MinikubeClientProvider[F] {

--- a/src/test/scala/com/goyeau/kubernetes/client/operation/MinikubeClientProvider.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/operation/MinikubeClientProvider.scala
@@ -12,7 +12,6 @@ trait MinikubeClientProvider[F[_]] extends BeforeAndAfter { this: Suite =>
 
   implicit def F: ConcurrentEffect[F]
   implicit def timer: Timer[F]
-  implicit def contextShift: ContextShift[IO]
   implicit def logger: Logger[F]
 
   val kubernetesClient: Resource[F, KubernetesClient[F]] = {

--- a/src/test/scala/com/goyeau/kubernetes/client/operation/ReplaceableTests.scala
+++ b/src/test/scala/com/goyeau/kubernetes/client/operation/ReplaceableTests.scala
@@ -6,10 +6,12 @@ import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.api.NamespacesApiTest
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.http4s.Status
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 trait ReplaceableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }]
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with MinikubeClientProvider[F] {


### PR DESCRIPTION
- Update Scala, SBT, scalatest, circe, http4s, sbt plugins and other dependencies
- Latest Akka does not require ActorMaterializer (removed)
- Drop unsupported scalac flags, rename other according to Scala 2.13 version
- Fix usage of deprecated Circe, Log4Cats and ScalaTest APIs
