### PR TITLE
switch to http4s jdk client for Pod exec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11.0.x
       - name: Style checks
+        uses: actions/setup-java@v1
+          with:
+            java-version: 11.0.x
         run: ./mill all __.checkFormat "__.fix --check" __.docJar
 
   integration-kubernetes-v1-18:
@@ -33,6 +32,9 @@ jobs:
           kubernetes version: v1.18.2
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test against Kubernetes v1.18.2
+        uses: actions/setup-java@v1
+          with:
+            java-version: 11.0.x
         run: ./mill __.test
 
   integration-kubernetes-v1-17:
@@ -49,6 +51,9 @@ jobs:
           kubernetes version: v1.17.5
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test against Kubernetes v1.17.5
+        uses: actions/setup-java@v1
+          with:
+            java-version: 11.0.x
         run: ./mill __.test
 
   integration-kubernetes-v1-16:
@@ -65,6 +70,9 @@ jobs:
           kubernetes version: v1.16.8
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test against Kubernetes v1.16.8
+        uses: actions/setup-java@v1
+          with:
+            java-version: 11.0.x
         run: ./mill __.test
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11.0.x
       - name: Style checks
         run: ./mill all __.checkFormat "__.fix --check" __.docJar
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Style checks
         uses: actions/setup-java@v1
-          with:
-            java-version: 11.0.x
+        with:
+          java-version: 11.0.x
         run: ./mill all __.checkFormat "__.fix --check" __.docJar
 
   integration-kubernetes-v1-18:
@@ -33,8 +33,8 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test against Kubernetes v1.18.2
         uses: actions/setup-java@v1
-          with:
-            java-version: 11.0.x
+        with:
+          java-version: 11.0.x
         run: ./mill __.test
 
   integration-kubernetes-v1-17:
@@ -52,8 +52,8 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test against Kubernetes v1.17.5
         uses: actions/setup-java@v1
-          with:
-            java-version: 11.0.x
+        with:
+          java-version: 11.0.x
         run: ./mill __.test
 
   integration-kubernetes-v1-16:
@@ -71,8 +71,8 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test against Kubernetes v1.16.8
         uses: actions/setup-java@v1
-          with:
-            java-version: 11.0.x
+        with:
+          java-version: 11.0.x
         run: ./mill __.test
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Style checks
+      - name: Setup Java 11
         uses: actions/setup-java@v1
         with:
           java-version: 11.0.x
+      - name: Style checks
         run: ./mill all __.checkFormat "__.fix --check" __.docJar
 
   integration-kubernetes-v1-18:
@@ -31,10 +32,11 @@ jobs:
           minikube version: v1.9.2
           kubernetes version: v1.18.2
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Test against Kubernetes v1.18.2
+      - name: Setup Java 11
         uses: actions/setup-java@v1
         with:
           java-version: 11.0.x
+      - name: Test against Kubernetes v1.18.2
         run: ./mill __.test
 
   integration-kubernetes-v1-17:
@@ -50,10 +52,11 @@ jobs:
           minikube version: v1.9.2
           kubernetes version: v1.17.5
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Test against Kubernetes v1.17.5
+      - name: Setup Java 11
         uses: actions/setup-java@v1
         with:
           java-version: 11.0.x
+      - name: Test against Kubernetes v1.17.5
         run: ./mill __.test
 
   integration-kubernetes-v1-16:
@@ -69,10 +72,11 @@ jobs:
           minikube version: v1.9.2
           kubernetes version: v1.16.8
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Test against Kubernetes v1.16.8
+      - name: Setup Java 11
         uses: actions/setup-java@v1
         with:
           java-version: 11.0.x
+      - name: Test against Kubernetes v1.16.8
         run: ./mill __.test
 
   publish:

--- a/build.sc
+++ b/build.sc
@@ -25,12 +25,15 @@ class KubernetesClientModule(val crossScalaVersion: String)
     super.scalacOptions().filter(_ != "-Wunused:imports") ++
       (if (crossScalaVersion.startsWith("2.12")) Seq("-Ypartial-unification") else Seq.empty)
   override def ivyDeps =
-    super.ivyDeps() ++ http4s ++ akkaHttp ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging
+    super.ivyDeps() ++ http4s ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging
 
   object test extends Tests {
     def testFrameworks    = Seq("org.scalatest.tools.Framework")
     override def forkArgs = super.forkArgs() :+ "-Djdk.tls.client.protocols=TLSv1.2"
     override def ivyDeps  = super.ivyDeps() ++ Agg(ivy"org.scalatest::scalatest:3.1.1")
+    def testOne(args: String*) = T.command {
+      super.runMain("org.scalatest.run", args: _*)
+    }
   }
 
   def pomSettings =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesException.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesException.scala
@@ -1,6 +1,0 @@
-package com.goyeau.kubernetes.client
-
-import akka.http.scaladsl.model.Uri
-
-case class KubernetesException(statusCode: Int, uri: Uri, message: String)
-    extends Exception(s"$uri returned $statusCode: $message")

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -4,6 +4,7 @@ import cats.effect.{Async, ConcurrentEffect, ContextShift}
 import cats.kernel.Monoid
 import cats.syntax.either._
 import com.goyeau.kubernetes.client.KubeConfig
+import com.goyeau.kubernetes.client.api.ExecStream.{StdErr, StdOut}
 import com.goyeau.kubernetes.client.operation._
 import fs2.Pipe
 import io.circe._
@@ -29,9 +30,13 @@ private[client] case class PodsApi[F[_]](httpClient: Client[F], wsClient: WSClie
   def namespace(namespace: String): NamespacedPodsApi[F] = NamespacedPodsApi(httpClient, wsClient, config, namespace)
 }
 
-sealed trait ExecStream
-final case class StdOut(data: String) extends ExecStream
-final case class StdErr(data: String) extends ExecStream
+sealed trait ExecStream {
+  def data: String
+}
+object ExecStream {
+  final case class StdOut(data: String) extends ExecStream
+  final case class StdErr(data: String) extends ExecStream
+}
 
 private[client] case class NamespacedPodsApi[F[_]](
     httpClient: Client[F],

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PodsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PodsApiTest.scala
@@ -1,14 +1,17 @@
 package com.goyeau.kubernetes.client.api
 
 import cats.effect.{ConcurrentEffect, IO}
-import com.goyeau.kubernetes.client.KubernetesClient
+import cats.implicits._
 import com.goyeau.kubernetes.client.operation._
+import com.goyeau.kubernetes.client.{KubernetesClient, Utils}
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
-import io.k8s.api.core.v1.{Container, Pod, PodList, PodSpec}
-import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
-import org.scalatest.flatspec.AnyFlatSpec
+import io.k8s.api.core.v1._
+import io.k8s.apimachinery.pkg.apis.meta.v1
+import io.k8s.apimachinery.pkg.apis.meta.v1.{ListMeta, ObjectMeta}
+import org.http4s.Status
 import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class PodsApiTest
@@ -32,15 +35,17 @@ class PodsApiTest
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =
     client.pods.namespace(namespaceName)
 
-  override def sampleResource(resourceName: String, labels: Map[String, String]) = Pod(
-    metadata = Option(ObjectMeta(name = Option(resourceName), labels = Option(labels))),
-    spec = Option(PodSpec(nodeName = Some("minikube"), containers = Seq(Container("test", image = Option("docker")))))
-  )
+  override def sampleResource(resourceName: String, labels: Map[String, String]) =
+    Pod(
+      metadata = Option(ObjectMeta(name = Option(resourceName), labels = Option(labels))),
+      spec = Option(PodSpec(containers = Seq(Container("test", image = Option("busybox")))))
+    )
   val activeDeadlineSeconds = Option(5L)
-  override def modifyResource(resource: Pod) = resource.copy(
-    metadata = Option(ObjectMeta(name = resource.metadata.flatMap(_.name))),
-    spec = resource.spec.map(_.copy(activeDeadlineSeconds = activeDeadlineSeconds))
-  )
+  override def modifyResource(resource: Pod) =
+    resource.copy(
+      metadata = Option(ObjectMeta(name = resource.metadata.flatMap(_.name))),
+      spec = resource.spec.map(_.copy(activeDeadlineSeconds = activeDeadlineSeconds))
+    )
   override def checkUpdated(updatedResource: Pod) =
     updatedResource.spec.value.activeDeadlineSeconds shouldBe activeDeadlineSeconds
 
@@ -49,4 +54,60 @@ class PodsApiTest
 
   override def watchApi(namespaceName: String)(implicit client: KubernetesClient[IO]): Watchable[IO, Pod] =
     client.pods.namespace(namespaceName)
+
+  it should "exec into pod" in {
+    val namespaceName = resourceName.toLowerCase
+    val name          = resourceName.toLowerCase + "-exec"
+    val testPod = Pod(
+      metadata = Option(ObjectMeta(name = Option(name))),
+      spec = Option(
+        PodSpec(containers =
+          Seq(
+            Container(
+              "test",
+              image = Option("docker"),
+              command = Option(Seq("sh", "-c", "tail -f /dev/null"))
+            )
+          )
+        )
+      )
+    )
+    val res = kubernetesClient
+      .use { implicit client =>
+        for {
+          status <- namespacedApi(namespaceName).create(testPod)
+          _ = status shouldBe Status.Created
+          pod <- waitUntilReady(namespaceName, name)
+          res <- namespacedApi(namespaceName).exec(
+            pod.metadata.get.name.get,
+            (es: ExecStream) => List(es),
+            pod.spec.flatMap(_.containers.headOption.map(_.name)),
+            Seq("ls")
+          )
+        } yield res
+      }
+      .unsafeRunSync()
+    val (messages, status) = res
+
+    status should be(Right(v1.Status(status = Some("Success"), metadata = Some(ListMeta()))))
+
+    messages.length shouldNot be(0)
+    val stdOut = messages.collect {
+      case StdOut(d) => d
+    }.mkString("")
+    stdOut should include regex("dev|etc|home|usr|var")
+
+    messages.collect { case StdErr(d) => d }.length should be(0)
+  }
+
+  def waitUntilReady(namespaceName: String, name: String)(implicit client: KubernetesClient[IO]): IO[Pod] =
+    Utils.retry(for {
+      pod <- getChecked(namespaceName, name)
+      notStarted  = pod.status.flatMap(_.conditions.map(_.exists(c => c.status == "False"))).getOrElse(false)
+      statusCount = pod.status.flatMap(_.conditions.map(_.length)).getOrElse(0)
+      _ <-
+        if (notStarted || statusCount != 4)
+          IO.raiseError(new RuntimeException("Pod is not started"))
+        else IO.unit
+    } yield pod)
 }

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/MinikubeClientProvider.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/MinikubeClientProvider.scala
@@ -13,6 +13,7 @@ trait MinikubeClientProvider[F[_]] extends BeforeAndAfterAll with ParallelTestEx
 
   implicit def F: ConcurrentEffect[F]
   implicit def timer: Timer[F]
+  implicit def contextShift: ContextShift[F]
   implicit def logger: Logger[F]
 
   val kubernetesClient: Resource[F, KubernetesClient[F]] = {

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -13,19 +13,13 @@ object Dependencies {
 
   lazy val http4s = {
     val version = "0.21.2"
+    val jdkClientVersion = "0.3.0"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",
       ivy"org.http4s::http4s-circe:$version",
       ivy"org.http4s::http4s-blaze-server:$version",
-      ivy"org.http4s::http4s-blaze-client:$version"
-    )
-  }
-
-  val akkaHttpVersion = "10.1.11"
-  lazy val akkaHttp = {
-    Agg(
-      ivy"com.typesafe.akka::akka-http:$akkaHttpVersion",
-      ivy"com.typesafe.akka::akka-stream:2.6.4"
+      ivy"org.http4s::http4s-blaze-client:$version",
+      ivy"org.http4s::http4s-jdk-http-client:$jdkClientVersion"
     )
   }
 
@@ -42,8 +36,7 @@ object Dependencies {
 
   lazy val tests = Agg(
     ivy"org.scalatest::scalatest:3.1.1",
-    ivy"com.github.julien-truffaut::monocle-core:2.0.4",
-    ivy"com.typesafe.akka::akka-http-testkit:$akkaHttpVersion"
+    ivy"com.github.julien-truffaut::monocle-core:2.0.4"
   )
 
 }


### PR DESCRIPTION
Here is a PR to switch to http4s jdk client to perform Pod exec. This removes akka-http dependecy.

One caveat: http4s-jdk client requires JDK11, so that our kubernetes-client will require Java 11 or higher. I think it is fair requirement, since JDK11 became default version for production today.