### PR TITLE
Http4s 0.22

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubeConfig.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubeConfig.scala
@@ -5,7 +5,7 @@ import java.io.File
 import cats.ApplicativeError
 import cats.effect.Sync
 import com.goyeau.kubernetes.client.util.Yamls
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.http4s.Uri
 import org.http4s.headers.Authorization
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -8,7 +8,7 @@ import com.goyeau.kubernetes.client.crd.{CrdContext, CustomResource, CustomResou
 import com.goyeau.kubernetes.client.util.SslContexts
 import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
-import org.http4s.jdkhttpclient.{WSClient, JdkHttpClient, JdkWSClient}
+import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient, WSClient}
 
 class KubernetesClient[F[_]: Sync](httpClient: Client[F], wsClient: WSClient[F], config: KubeConfig) {
   lazy val namespaces = new NamespacesApi(httpClient, config)

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -8,9 +8,7 @@ import com.goyeau.kubernetes.client.crd.{CrdContext, CustomResource, CustomResou
 import com.goyeau.kubernetes.client.util.SslContexts
 import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
-import org.http4s.client.jdkhttpclient.{JdkHttpClient, JdkWSClient}
-
-import org.http4s.client.jdkhttpclient.WSClient
+import org.http4s.jdkhttpclient.{WSClient, JdkHttpClient, JdkWSClient}
 
 class KubernetesClient[F[_]: Sync](httpClient: Client[F], wsClient: WSClient[F], config: KubeConfig) {
   lazy val namespaces = new NamespacesApi(httpClient, config)
@@ -52,5 +50,5 @@ object KubernetesClient {
     }
 
   def apply[F[_]: ConcurrentEffect: ContextShift](config: F[KubeConfig]): Resource[F, KubernetesClient[F]] =
-    Resource.liftF(config).flatMap(apply(_))
+    Resource.eval(config).flatMap(apply(_))
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourcesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourcesApi.scala
@@ -54,7 +54,7 @@ private[client] class NamespacedCustomResourcesApi[F[_], A, B](
       .run(
         Request[F](PUT, config.server.resolve(resourceUri / name / "status"))
           .withEntity(resource)
-          .putHeaders(config.authorization.toSeq: _*)
+          .withOptionalAuthorization(config.authorization)
       )
       .use(
         EnrichedStatus[F]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -13,7 +13,7 @@ import io.k8s.api.core.v1.{Pod, PodList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.Status
 import org.http4s._
 import org.http4s.client.Client
-import org.http4s.client.jdkhttpclient._
+import org.http4s.jdkhttpclient._
 import org.http4s.implicits._
 import scodec.bits.ByteVector
 import org.typelevel.ci.CIString
@@ -61,10 +61,8 @@ private[client] class NamespacedPodsApi[F[_]](
 
   val execHeaders: Headers =
     Headers(
-      config.authorization.map(_.toRaw).toList ++ List(
-        Header.Raw(CIString("Sec-WebSocket-Protocol"), "v4.channel.k8s.io")
-      )
-    )
+      config.authorization.toList
+    ).put(Header.Raw(CIString("Sec-WebSocket-Protocol"), "v4.channel.k8s.io"))
 
   val webSocketAddress: Uri = Uri.unsafeFromString(
     config.server

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -16,6 +16,7 @@ import org.http4s.client.Client
 import org.http4s.client.jdkhttpclient._
 import org.http4s.implicits._
 import scodec.bits.ByteVector
+import org.typelevel.ci.CIString
 
 private[client] class PodsApi[F[_]](val httpClient: Client[F], wsClient: WSClient[F], val config: KubeConfig)(implicit
     val F: Sync[F],
@@ -59,8 +60,10 @@ private[client] class NamespacedPodsApi[F[_]](
   val resourceUri: Uri = uri"/api" / "v1" / "namespaces" / namespace / "pods"
 
   val execHeaders: Headers =
-    Headers.of(
-      config.authorization.toList ++ headers.`Sec-WebSocket-Protocol`.parse("v4.channel.k8s.io").toOption.toList: _*
+    Headers(
+      config.authorization.map(_.toRaw).toList ++ List(
+        Header.Raw(CIString("Sec-WebSocket-Protocol"), "v4.channel.k8s.io")
+      )
     )
 
   val webSocketAddress: Uri = Uri.unsafeFromString(
@@ -80,12 +83,12 @@ private[client] class NamespacedPodsApi[F[_]](
       tty: Boolean = false
   ): F[(T, Either[String, Status])] = {
     val uri = (webSocketAddress.resolve(resourceUri) / podName / "exec")
-      .+?("stdin", stdin.toString)
-      .+?("stdout", stdout.toString)
-      .+?("stderr", stderr.toString)
-      .+?("tty", tty.toString)
-      .+??("container", container)
-      .+?("command", command)
+      .+?("stdin" -> stdin.toString)
+      .+?("stdout" -> stdout.toString)
+      .+?("stderr" -> stderr.toString)
+      .+?("tty" -> tty.toString)
+      .+??("container" -> container)
+      .++?("command" -> command)
 
     val request = WSRequest(uri, execHeaders, Method.POST)
     wsClient.connectHighLevel(request).use { connection =>

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Creatable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Creatable.scala
@@ -25,7 +25,7 @@ private[client] trait Creatable[F[_], Resource <: { def metadata: Option[ObjectM
       .run(
         Request[F](POST, config.server.resolve(resourceUri))
           .withEntity(resource)
-          .putHeaders(config.authorization.toSeq: _*)
+          .withOptionalAuthorization(config.authorization)
       )
       .use(
         EnrichedStatus[F]
@@ -39,13 +39,14 @@ private[client] trait Creatable[F[_], Resource <: { def metadata: Option[ObjectM
           Request[F](PATCH, fullResourceUri)
             .withEntity(resource)
             .putHeaders(
-              `Content-Type`(MediaType.application.`merge-patch+json`) +: config.authorization.toSeq: _*
+              `Content-Type`(MediaType.application.`merge-patch+json`)
             )
+            .withOptionalAuthorization(config.authorization)
         )
         .use(EnrichedStatus[F])
 
     httpClient
-      .run(Request[F](GET, fullResourceUri).putHeaders(config.authorization.toSeq: _*))
+      .run(Request[F](GET, fullResourceUri).withOptionalAuthorization(config.authorization))
       .use(EnrichedStatus.apply[F])
       .flatMap {
         case status if status.isSuccess => update

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Deletable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Deletable.scala
@@ -19,7 +19,7 @@ private[client] trait Deletable[F[_]] {
   def delete(name: String, deleteOptions: Option[DeleteOptions] = None): F[Status] = {
     implicit val encoder: EntityEncoder[F, Option[DeleteOptions]] =
       EntityEncoder.encodeBy(`Content-Type`(MediaType.application.json)) { opt =>
-        opt.fold(Entity.empty.asInstanceOf[Entity[F]])(EntityEncoder[F, DeleteOptions].toEntity(_))
+        opt.fold(Entity[F](EmptyBody.covary[F], Some(0L)))(EntityEncoder[F, DeleteOptions].toEntity(_))
       }
 
     httpClient

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Gettable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Gettable.scala
@@ -17,6 +17,7 @@ private[client] trait Gettable[F[_], Resource] {
 
   def get(name: String): F[Resource] =
     httpClient.expect[Resource](
-      Request[F](GET, config.server.resolve(resourceUri) / name).putHeaders(config.authorization.toSeq: _*)
+      Request[F](GET, config.server.resolve(resourceUri) / name).withOptionalAuthorization(config.authorization)
     )
+
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Gettable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Gettable.scala
@@ -19,5 +19,4 @@ private[client] trait Gettable[F[_], Resource] {
     httpClient.expect[Resource](
       Request[F](GET, config.server.resolve(resourceUri) / name).withOptionalAuthorization(config.authorization)
     )
-
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/GroupDeletable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/GroupDeletable.scala
@@ -16,6 +16,8 @@ private[client] trait GroupDeletable[F[_]] {
 
   def deleteAll(labels: Map[String, String] = Map.empty): F[Status] = {
     val uri = addLabels(labels, config.server.resolve(resourceUri))
-    httpClient.run(Request[F](DELETE, uri).putHeaders(config.authorization.toSeq: _*)).use(EnrichedStatus[F])
+    httpClient
+      .run(Request[F](DELETE, uri).withOptionalAuthorization(config.authorization))
+      .use(EnrichedStatus[F])
   }
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Listable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Listable.scala
@@ -18,6 +18,6 @@ private[client] trait Listable[F[_], Resource] {
 
   def list(labels: Map[String, String] = Map.empty): F[Resource] = {
     val uri = addLabels(labels, config.server.resolve(resourceUri))
-    httpClient.expect[Resource](Request[F](GET, uri).putHeaders(config.authorization.toSeq: _*))
+    httpClient.expect[Resource](Request[F](GET, uri).withOptionalAuthorization(config.authorization))
   }
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Proxy.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Proxy.scala
@@ -3,9 +3,9 @@ package com.goyeau.kubernetes.client.operation
 import cats.effect.Sync
 import com.goyeau.kubernetes.client.KubeConfig
 import org.http4s._
-import org.http4s.dsl.impl.Path
 import org.http4s.client.Client
 import org.http4s.EntityDecoder
+import org.http4s.Uri.Path
 import org.http4s.headers.`Content-Type`
 
 private[client] trait Proxy[F[_]] {
@@ -24,6 +24,7 @@ private[client] trait Proxy[F[_]] {
     httpClient.expect[String](
       Request(
         method,
+        //TODO: I think this is wrong (hamnis)
         config.server.resolve(resourceUri) / name / s"proxy$path",
         headers = Headers(config.authorization.toList),
         body = data.fold[EntityBody[F]](EmptyBody)(

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Replaceable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Replaceable.scala
@@ -23,9 +23,7 @@ private[client] trait Replaceable[F[_], Resource <: { def metadata: Option[Objec
       .run(
         Request[F](PUT, config.server.resolve(resourceUri) / resource.metadata.get.name.get)
           .withEntity(resource)
-          .putHeaders(
-            config.authorization.toSeq: _*
-          )
+          .withOptionalAuthorization(config.authorization)
       )
       .use(EnrichedStatus[F])
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Watchable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Watchable.scala
@@ -25,7 +25,7 @@ private[client] trait Watchable[F[_], Resource] {
 
   def watch(labels: Map[String, String] = Map.empty): Stream[F, Either[String, WatchEvent[Resource]]] = {
     val uri = addLabels(labels, config.server.resolve(watchResourceUri))
-    val req = Request[F](GET, uri.withQueryParam("watch", "1")).putHeaders(config.authorization.toSeq: _*)
+    val req = Request[F](GET, uri.withQueryParam("watch", "1")).withOptionalAuthorization(config.authorization)
     jsonStream(req).map(_.as[WatchEvent[Resource]].leftMap(_.getMessage))
   }
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
@@ -1,0 +1,11 @@
+package com.goyeau.kubernetes.client
+
+import org.http4s.Request
+import org.http4s.headers.Authorization
+
+package object operation {
+  implicit private[client] class KubernetesRequestOps[F[_]](request: Request[F]) {
+    def withOptionalAuthorization(auth: Option[Authorization]): Request[F] =
+      auth.map(request.putHeaders(_)).getOrElse(request)
+  }
+}

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
@@ -6,6 +6,6 @@ import org.http4s.headers.Authorization
 package object operation {
   implicit private[client] class KubernetesRequestOps[F[_]](request: Request[F]) {
     def withOptionalAuthorization(auth: Option[Authorization]): Request[F] =
-      auth.map(request.putHeaders(_)).getOrElse(request)
+      auth.fold(request)(request.putHeaders(_))
   }
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/Uris.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/Uris.scala
@@ -4,6 +4,6 @@ import org.http4s.Uri
 
 object Uris {
   def addLabels(labels: Map[String, String], uri: Uri): Uri =
-    if (labels.nonEmpty) uri.+?("labelSelector", labels.map { case (k, v) => s"$k=$v" }.mkString(","))
+    if (labels.nonEmpty) uri.+?("labelSelector" -> labels.map { case (k, v) => s"$k=$v" }.mkString(","))
     else uri
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/Yamls.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/Yamls.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import com.goyeau.kubernetes.client.KubeConfig
 
 import scala.io.Source
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto._
 import io.circe.yaml.parser._

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ConfigMapsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ConfigMapsApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect._
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.{ConfigMap, ConfigMapList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CronJobsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CronJobsApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect.{ConcurrentEffect, IO}
 import com.goyeau.kubernetes.client.operation._
 import com.goyeau.kubernetes.client.KubernetesClient
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.batch.v1.JobSpec
 import io.k8s.api.batch.v1beta1.{CronJob, CronJobList, CronJobSpec, JobTemplateSpec}
 import io.k8s.api.core.v1._

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourceDefinitionsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourceDefinitionsApiTest.scala
@@ -5,8 +5,8 @@ import cats.syntax.option._
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.api.CustomResourceDefinitionsApiTest._
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.apiextensionsapiserver.pkg.apis.apiextensions.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourcesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourcesApiTest.scala
@@ -7,8 +7,8 @@ import com.goyeau.kubernetes.client.api.CustomResourceDefinitionsApiTest._
 import com.goyeau.kubernetes.client.api.CustomResourcesApiTest.{CronTabResource, CronTabResourceList}
 import com.goyeau.kubernetes.client.crd.{CrdContext, CustomResource, CustomResourceList}
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.circe._
 import io.circe.generic.semiauto._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/DeploymentsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/DeploymentsApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect.{ConcurrentEffect, IO}
 import com.goyeau.kubernetes.client.operation._
 import com.goyeau.kubernetes.client.{IntValue, KubernetesClient, StringValue}
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.apps.v1._
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect._
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.autoscaling.v1.{CrossVersionObjectReference, HorizontalPodAutoscaler, HorizontalPodAutoscalerList, HorizontalPodAutoscalerSpec}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/IngressesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/IngressesApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect._
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.networking.v1beta1.{Ingress, IngressList, IngressRule, IngressSpec}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/JobsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/JobsApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect.{ConcurrentEffect, IO}
 import com.goyeau.kubernetes.client.operation._
 import com.goyeau.kubernetes.client.KubernetesClient
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.batch.v1.{Job, JobList, JobSpec}
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/NamespacesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/NamespacesApiTest.scala
@@ -6,8 +6,8 @@ import cats.implicits._
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.Utils._
 import com.goyeau.kubernetes.client.operation.MinikubeClientProvider
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.{Namespace, NamespaceList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import org.http4s.Status

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PodsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PodsApiTest.scala
@@ -5,8 +5,8 @@ import cats.implicits._
 import com.goyeau.kubernetes.client.api.ExecStream.{StdErr, StdOut}
 import com.goyeau.kubernetes.client.operation._
 import com.goyeau.kubernetes.client.{KubernetesClient, Utils}
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1
 import io.k8s.apimachinery.pkg.apis.meta.v1.{ListMeta, ObjectMeta}

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ReplicaSetsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ReplicaSetsApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect.{ConcurrentEffect, IO}
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.apps.v1._
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect.{ConcurrentEffect, IO}
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.{Secret, SecretList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import java.util.Base64

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServiceAccountsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServiceAccountsApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect._
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServicesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServicesApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect._
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/StatefulSetsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/StatefulSetsApiTest.scala
@@ -3,8 +3,8 @@ package com.goyeau.kubernetes.client.api
 import cats.effect.{ConcurrentEffect, IO}
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.apps.v1._
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/MinikubeClientProvider.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/MinikubeClientProvider.scala
@@ -4,7 +4,7 @@ import cats.effect._
 import cats.implicits._
 import com.goyeau.kubernetes.client.api.NamespacesApiTest
 import com.goyeau.kubernetes.client.{KubeConfig, KubernetesClient}
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import java.io.File
 import munit.Suite
 

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -12,12 +12,11 @@ object Dependencies {
   }
 
   lazy val http4s = {
-    val version = "0.21.13"
-    val jdkClientVersion = "0.3.5"
+    val version = "0.22.0-M5"
+    val jdkClientVersion = "0.4-13-45359e8-SNAPSHOT"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",
       ivy"org.http4s::http4s-circe:$version",
-      ivy"org.http4s::http4s-blaze-client:$version",
       ivy"org.http4s::http4s-jdk-http-client:$jdkClientVersion"
     )
   }

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -13,7 +13,7 @@ object Dependencies {
 
   lazy val http4s = {
     val version = "0.22.0-M5"
-    val jdkClientVersion = "0.4-13-45359e8-SNAPSHOT"
+    val jdkClientVersion = "0.4.0-M1"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",
       ivy"org.http4s::http4s-circe:$version",

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -13,7 +13,7 @@ object Dependencies {
 
   lazy val http4s = {
     val version = "0.22.0-M5"
-    val jdkClientVersion = "0.4.0-M1"
+    val jdkClientVersion = "0.4.0-M2"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",
       ivy"org.http4s::http4s-circe:$version",

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -12,8 +12,8 @@ object Dependencies {
   }
 
   lazy val http4s = {
-    val version = "0.22.0-M5"
-    val jdkClientVersion = "0.4.0-M2"
+    val version = "0.22.0-RC1"
+    val jdkClientVersion = "0.4.0-RC1"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",
       ivy"org.http4s::http4s-circe:$version",
@@ -21,11 +21,11 @@ object Dependencies {
     )
   }
 
-  lazy val circeYaml = Agg(ivy"io.circe::circe-yaml:0.13.1")
+  lazy val circeYaml = Agg(ivy"io.circe::circe-yaml:0.14.0")
 
   lazy val bouncycastle = Agg(ivy"org.bouncycastle:bcpkix-jdk15on:1.68")
 
   lazy val collectionCompat = Agg(ivy"org.scala-lang.modules::scala-collection-compat:2.4.4")
 
-  lazy val logging = Agg(ivy"io.chrisdavenport::log4cats-slf4j:1.1.1")
+  lazy val logging = Agg(ivy"org.typelevel::log4cats-slf4j:1.3.1")
 }


### PR DESCRIPTION
Port to Http4s 0.22

Dropped the blaze dependency as that is unneeded. 
We have everything we need in the jdk-11 client.

This is a major bump, and should probably be released as a milestone.
Http4s 0.22 allows to go to Scala 3, and keep Cats-Effect 2
