### PR TITLE
Migrate to cats-effect-3 and new http4s release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ ENV/
 .bsp
 .metals
 .bloop
+.vscode
 metals.sbt
 build.properties
 .idea

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.7.5
+version = "3.0.0-RC3"
 project.git = true
 maxColumn = 120
 align = more
@@ -6,3 +6,4 @@ assumeStandardLibraryStripMargin = true
 rewrite.rules = [AvoidInfix, SortImports, RedundantBraces, RedundantParens, SortModifiers]
 rewrite.redundantBraces.stringInterpolation = true
 spaces.afterTripleEquals = true
+runner.dialect = scala213source3

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,7 @@
 version = "3.0.0-RC3"
 project.git = true
 maxColumn = 120
-align = more
+align.preset = "more"
 assumeStandardLibraryStripMargin = true
 rewrite.rules = [AvoidInfix, SortImports, RedundantBraces, RedundantParens, SortModifiers]
 rewrite.redundantBraces.stringInterpolation = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Client for Scala
 
-[![Latest version](https://index.scala-lang.org/joan38/kubernetes-client/kubernetes-client/latest.svg?color=blue)](https://index.scala-lang.org/joan38/kubernetes-client/kubernetes-client)
+[![kubernetes-client Scala version support](https://index.scala-lang.org/joan38/kubernetes-client/kubernetes-client/latest-by-scala-version.svg)](https://index.scala-lang.org/joan38/kubernetes-client/kubernetes-client)
 
 A pure functional client for Kubernetes.
 
@@ -20,7 +20,7 @@ or
 
 ### Client configuration example
 ```scala
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.IO
 import com.goyeau.kubernetes.client._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -32,13 +32,11 @@ import org.http4s.implicits._
 import scala.concurrent.ExecutionContext
 import scala.io.Source
 
-implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
-implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val kubernetesClient =
   KubernetesClient[IO](
-    KubeConfig(
+    KubeConfig.of[IO](
       server = uri"https://k8s.goyeau.com",
       authorization = Option(Authorization(Token(AuthScheme.Bearer, Source.fromFile("/var/run/secrets/kubernetes.io/serviceaccount/token").mkString))),
       caCertFile = Option(new File("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"))
@@ -47,15 +45,13 @@ val kubernetesClient =
 ```
 
 ```scala
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.IO
 import com.goyeau.kubernetes.client._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import java.io.File
 import scala.concurrent.ExecutionContext
 
-implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
-implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val kubernetesClient =
@@ -65,7 +61,7 @@ val kubernetesClient =
 ### Requests
 
 ```scala
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.IO
 import com.goyeau.kubernetes.client._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -76,8 +72,6 @@ import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import java.io.File
 import scala.concurrent.ExecutionContext
 
-implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
-implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
 val kubernetesClient =

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ or
 ```scala
 import cats.effect.{ContextShift, IO, Timer}
 import com.goyeau.kubernetes.client._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import java.io.File
 import org.http4s.AuthScheme
 import org.http4s.Credentials.Token
@@ -49,8 +49,8 @@ val kubernetesClient =
 ```scala
 import cats.effect.{ContextShift, IO, Timer}
 import com.goyeau.kubernetes.client._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import java.io.File
 import scala.concurrent.ExecutionContext
 
@@ -67,8 +67,8 @@ val kubernetesClient =
 ```scala
 import cats.effect.{ContextShift, IO, Timer}
 import com.goyeau.kubernetes.client._
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.apps.v1._
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.api.resource.Quantity
@@ -135,6 +135,14 @@ kubernetesClient.use { client =>
   client.deployments.namespace("my-namespace").create(deployment)
 }
 ```
+
+
+## Development
+
+### Pre-requisites
+
+ - Java 11 or higher
+ - Docker
 
 
 ## Related projects

--- a/build.sc
+++ b/build.sc
@@ -19,7 +19,8 @@ class KubernetesClientModule(val crossScalaVersion: String)
     with GitVersionedPublishModule
     with SwaggerModelGenerator {
 
-  override def scalacOptions = super.scalacOptions()
+  override def scalacOptions =    
+    super.scalacOptions()
     .filter(_ != "-Wunused:imports")
     .filter(_ != "-Xfatal-warnings")
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ConfigMapsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ConfigMapsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class ConfigMapsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[ConfigMapList],
     encoder: Encoder[ConfigMap],
     decoder: Decoder[ConfigMap]
@@ -26,7 +26,7 @@ private[client] class NamespacedConfigMapsApi[F[_]](
     val config: KubeConfig,
     val namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[ConfigMap],
     val resourceDecoder: Decoder[ConfigMap],
     val listDecoder: Decoder[ConfigMapList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CronJobsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CronJobsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class CronJobsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[CronJobList],
     encoder: Encoder[CronJob],
     decoder: Decoder[CronJob]
@@ -22,7 +22,7 @@ private[client] class CronJobsApi[F[_]](val httpClient: Client[F], val config: K
 
 private[client] class NamespacedCronJobsApi[F[_]](val httpClient: Client[F], val config: KubeConfig, namespace: String)(
     implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[CronJob],
     val resourceDecoder: Decoder[CronJob],
     val listDecoder: Decoder[CronJobList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourceDefinitionsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourceDefinitionsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe.{Decoder, Encoder}
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class CustomResourceDefinitionsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[CustomResourceDefinitionList],
     val resourceEncoder: Encoder[CustomResourceDefinition],
     val resourceDecoder: Decoder[CustomResourceDefinition]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourcesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourcesApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.crd.{CrdContext, CustomResource, CustomResourceList}
 import com.goyeau.kubernetes.client.operation._
@@ -17,7 +17,7 @@ private[client] class CustomResourcesApi[F[_], A, B](
     val config: KubeConfig,
     val context: CrdContext
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[CustomResourceList[A, B]],
     encoder: Encoder[CustomResource[A, B]],
     decoder: Decoder[CustomResource[A, B]]
@@ -35,7 +35,7 @@ private[client] class NamespacedCustomResourcesApi[F[_], A, B](
     val context: CrdContext,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[CustomResource[A, B]],
     val resourceDecoder: Decoder[CustomResource[A, B]],
     val listDecoder: Decoder[CustomResourceList[A, B]]
@@ -56,7 +56,5 @@ private[client] class NamespacedCustomResourcesApi[F[_], A, B](
           .withEntity(resource)
           .withOptionalAuthorization(config.authorization)
       )
-      .use(
-        EnrichedStatus[F]
-      )
+      .use(EnrichedStatus[F])
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/DeploymentsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/DeploymentsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class DeploymentsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[DeploymentList],
     encoder: Encoder[Deployment],
     decoder: Decoder[Deployment]
@@ -26,7 +26,7 @@ private[client] class NamespacedDeploymentsApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[Deployment],
     val resourceDecoder: Decoder[Deployment],
     val listDecoder: Decoder[DeploymentList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class HorizontalPodAutoscalersApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[HorizontalPodAutoscalerList],
     encoder: Encoder[HorizontalPodAutoscaler],
     decoder: Decoder[HorizontalPodAutoscaler]
@@ -26,7 +26,7 @@ private[client] class NamespacedHorizontalPodAutoscalersApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[HorizontalPodAutoscaler],
     val resourceDecoder: Decoder[HorizontalPodAutoscaler],
     val listDecoder: Decoder[HorizontalPodAutoscalerList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/IngressesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/IngressesApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.implicits._
 import io.k8s.api.networking.v1beta1.{Ingress, IngressList}
 
 private[client] class IngressessApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[IngressList],
     encoder: Encoder[Ingress],
     decoder: Decoder[Ingress]
@@ -26,7 +26,7 @@ private[client] class NamespacedIngressesApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[Ingress],
     val resourceDecoder: Decoder[Ingress],
     val listDecoder: Decoder[IngressList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/JobsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/JobsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class JobsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[JobList],
     encoder: Encoder[Job],
     decoder: Decoder[Job]
@@ -25,7 +25,7 @@ private[client] class NamespacedJobsApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[Job],
     val resourceDecoder: Decoder[Job],
     val listDecoder: Decoder[JobList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/NamespacesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/NamespacesApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe.{Decoder, Encoder}
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class NamespacesApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[NamespaceList],
     val resourceEncoder: Encoder[Namespace],
     val resourceDecoder: Decoder[Namespace]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodDisruptionBudgetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodDisruptionBudgetsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class PodDisruptionBudgetsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[PodDisruptionBudgetList],
     encoder: Encoder[PodDisruptionBudget],
     decoder: Decoder[PodDisruptionBudget]
@@ -26,7 +26,7 @@ private[client] class NamespacedPodDisruptionBudgetApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[PodDisruptionBudget],
     val resourceDecoder: Decoder[PodDisruptionBudget],
     val listDecoder: Decoder[PodDisruptionBudgetList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import cats.kernel.Monoid
 import cats.syntax.either._
 import com.goyeau.kubernetes.client.KubeConfig
@@ -19,7 +19,7 @@ import scodec.bits.ByteVector
 import org.typelevel.ci.CIString
 
 private[client] class PodsApi[F[_]](val httpClient: Client[F], wsClient: WSClient[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[PodList],
     encoder: Encoder[Pod],
     decoder: Decoder[Pod]
@@ -44,7 +44,7 @@ private[client] class NamespacedPodsApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[Pod],
     val resourceDecoder: Decoder[Pod],
     val listDecoder: Decoder[PodList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ReplicaSetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ReplicaSetsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class ReplicaSetsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[ReplicaSetList],
     encoder: Encoder[ReplicaSet],
     decoder: Decoder[ReplicaSet]
@@ -26,7 +26,7 @@ private[client] class NamespacedReplicaSetsApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[ReplicaSet],
     val resourceDecoder: Decoder[ReplicaSet],
     val listDecoder: Decoder[ReplicaSetList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/SecretsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/SecretsApi.scala
@@ -1,7 +1,7 @@
 package com.goyeau.kubernetes.client.api
 
 import java.util.Base64
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 import scala.collection.compat._
 
 private[client] class SecretsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[SecretList],
     encoder: Encoder[Secret],
     decoder: Decoder[Secret]
@@ -27,7 +27,7 @@ private[client] class NamespacedSecretsApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[Secret],
     val resourceDecoder: Decoder[Secret],
     val listDecoder: Decoder[SecretList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServiceAccountsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServiceAccountsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class ServiceAccountsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[ServiceAccountList],
     encoder: Encoder[ServiceAccount],
     decoder: Decoder[ServiceAccount]
@@ -26,7 +26,7 @@ private[client] class NamespacedServiceAccountsApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[ServiceAccount],
     val resourceDecoder: Decoder[ServiceAccount],
     val listDecoder: Decoder[ServiceAccountList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServicesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServicesApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class ServicesApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[ServiceList],
     encoder: Encoder[Service],
     decoder: Decoder[Service]
@@ -25,7 +25,7 @@ private[client] class NamespacedServicesApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[Service],
     val resourceDecoder: Decoder[Service],
     val listDecoder: Decoder[ServiceList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/StatefulSetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/StatefulSetsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 
 private[client] class StatefulSetsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val listDecoder: Decoder[StatefulSetList],
     encoder: Encoder[StatefulSet],
     decoder: Decoder[StatefulSet]
@@ -26,7 +26,7 @@ private[client] class NamespacedStatefulSetsApi[F[_]](
     val config: KubeConfig,
     namespace: String
 )(implicit
-    val F: Sync[F],
+    val F: Async[F],
     val resourceEncoder: Encoder[StatefulSet],
     val resourceDecoder: Decoder[StatefulSet],
     val listDecoder: Decoder[StatefulSetList]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/crd/RawExtension.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/crd/RawExtension.scala
@@ -4,32 +4,23 @@ import io.circe.syntax._
 
 /** RawExtension is used to hold extensions in external versions.
   *
-  * To use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.
+  * To use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your
+  * internal struct. You also need to register your various plugin types.
   *
-  * // Internal package: type MyAPIObject struct {
-  * runtime.TypeMeta `json:",inline"`
-  * MyPlugin runtime.Object `json:"myPlugin"`
-  * } type PluginA struct {
-  * AOption string `json:"aOption"`
-  * }
+  * // Internal package: type MyAPIObject struct { runtime.TypeMeta `json:",inline"` MyPlugin runtime.Object
+  * `json:"myPlugin"` } type PluginA struct { AOption string `json:"aOption"` }
   *
-  * // External package: type MyAPIObject struct {
-  * runtime.TypeMeta `json:",inline"`
-  * MyPlugin runtime.RawExtension `json:"myPlugin"`
-  * } type PluginA struct {
-  * AOption string `json:"aOption"`
-  * }
+  * // External package: type MyAPIObject struct { runtime.TypeMeta `json:",inline"` MyPlugin runtime.RawExtension
+  * `json:"myPlugin"` } type PluginA struct { AOption string `json:"aOption"` }
   *
-  * // On the wire, the JSON will look something like this: {
-  * "kind":"MyAPIObject",
-  * "apiVersion":"v1",
-  * "myPlugin": {
-  *  "kind":"PluginA",
-  *  "aOption":"foo",
-  * },
-  * }
+  * // On the wire, the JSON will look something like this: { "kind":"MyAPIObject", "apiVersion":"v1", "myPlugin": {
+  * "kind":"PluginA", "aOption":"foo", }, }
   *
-  * So what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)
+  * So what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject.
+  * That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the
+  * internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON
+  * stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case
+  * where the object is of an unknown type, a runtime.Unknown object will be created and stored.)
   */
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Creatable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Creatable.scala
@@ -2,7 +2,7 @@ package com.goyeau.kubernetes.client.operation
 
 import scala.language.reflectiveCalls
 import cats.implicits._
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.util.CirceEntityCodec._
 import com.goyeau.kubernetes.client.util.EnrichedStatus
@@ -15,7 +15,7 @@ import org.http4s.Method._
 
 private[client] trait Creatable[F[_], Resource <: { def metadata: Option[ObjectMeta] }] {
   protected def httpClient: Client[F]
-  implicit protected val F: Sync[F]
+  implicit protected val F: Async[F]
   protected def config: KubeConfig
   protected def resourceUri: Uri
   implicit protected def resourceEncoder: Encoder[Resource]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Deletable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Deletable.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.operation
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.util.CirceEntityCodec._
 import com.goyeau.kubernetes.client.util.EnrichedStatus
@@ -12,7 +12,7 @@ import org.http4s.headers.`Content-Type`
 
 private[client] trait Deletable[F[_]] {
   protected def httpClient: Client[F]
-  implicit protected val F: Sync[F]
+  implicit protected val F: Async[F]
   protected def config: KubeConfig
   protected def resourceUri: Uri
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Gettable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Gettable.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.operation
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.util.CirceEntityCodec._
 import io.circe._
@@ -10,7 +10,7 @@ import org.http4s.Method._
 
 private[client] trait Gettable[F[_], Resource] {
   protected def httpClient: Client[F]
-  implicit protected val F: Sync[F]
+  implicit protected val F: Async[F]
   protected def config: KubeConfig
   protected def resourceUri: Uri
   implicit protected def resourceDecoder: Decoder[Resource]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/GroupDeletable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/GroupDeletable.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.operation
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.util.EnrichedStatus
 import com.goyeau.kubernetes.client.util.Uris.addLabels
@@ -10,7 +10,7 @@ import org.http4s.Method._
 
 private[client] trait GroupDeletable[F[_]] {
   protected def httpClient: Client[F]
-  implicit protected val F: Sync[F]
+  implicit protected val F: Async[F]
   protected def config: KubeConfig
   protected def resourceUri: Uri
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Listable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Listable.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.operation
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.util.CirceEntityCodec._
 import com.goyeau.kubernetes.client.util.Uris.addLabels
@@ -11,7 +11,7 @@ import org.http4s.Method._
 
 private[client] trait Listable[F[_], Resource] {
   protected def httpClient: Client[F]
-  implicit protected val F: Sync[F]
+  implicit protected val F: Async[F]
   protected def config: KubeConfig
   protected def resourceUri: Uri
   implicit protected def listDecoder: Decoder[Resource]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Proxy.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Proxy.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.operation
 
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import org.http4s._
 import org.http4s.client.Client
@@ -10,7 +10,7 @@ import org.http4s.headers.`Content-Type`
 
 private[client] trait Proxy[F[_]] {
   protected def httpClient: Client[F]
-  implicit protected val F: Sync[F]
+  implicit protected val F: Async[F]
   protected def config: KubeConfig
   protected def resourceUri: Uri
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Replaceable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Replaceable.scala
@@ -1,7 +1,7 @@
 package com.goyeau.kubernetes.client.operation
 
 import scala.language.reflectiveCalls
-import cats.effect.Sync
+import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.util.CirceEntityCodec._
 import com.goyeau.kubernetes.client.util.EnrichedStatus
@@ -13,7 +13,7 @@ import org.http4s.Method._
 
 private[client] trait Replaceable[F[_], Resource <: { def metadata: Option[ObjectMeta] }] {
   protected def httpClient: Client[F]
-  implicit protected val F: Sync[F]
+  implicit protected val F: Async[F]
   protected def config: KubeConfig
   protected def resourceUri: Uri
   implicit protected def resourceEncoder: Encoder[Resource]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Watchable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Watchable.scala
@@ -1,13 +1,13 @@
 package com.goyeau.kubernetes.client.operation
 
-import cats.effect.Sync
+import cats.effect.Async
 import cats.syntax.either._
 import com.goyeau.kubernetes.client.util.Uris.addLabels
 import com.goyeau.kubernetes.client.{KubeConfig, WatchEvent}
 import fs2.Stream
 import io.circe.jawn.CirceSupportParser
 import io.circe.{Decoder, Json}
-import jawnfs2._
+import org.typelevel.jawn.fs2._
 import org.http4s.Method._
 import org.http4s._
 import org.http4s.client.Client
@@ -15,7 +15,7 @@ import org.typelevel.jawn.Facade
 
 private[client] trait Watchable[F[_], Resource] {
   protected def httpClient: Client[F]
-  implicit protected val F: Sync[F]
+  implicit protected val F: Async[F]
   protected def config: KubeConfig
   protected def resourceUri: Uri
   protected def watchResourceUri: Uri = resourceUri

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/CirceEntityCodec.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/CirceEntityCodec.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.util
 
-import cats.effect.Sync
+import cats.effect.Concurrent
 import io.circe.{Decoder, Encoder, Printer}
 import org.http4s.{EntityDecoder, EntityEncoder}
 import org.http4s.circe.CirceInstances
@@ -8,6 +8,6 @@ import org.http4s.circe.CirceInstances
 private[client] object CirceEntityCodec extends CirceInstances {
   override val defaultPrinter: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
-  implicit def circeEntityEncoder[F[_], A: Encoder]: EntityEncoder[F, A]       = jsonEncoderOf[F, A]
-  implicit def circeEntityDecoder[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] = jsonOf[F, A]
+  implicit def circeEntityEncoder[F[_], A: Encoder]: EntityEncoder[F, A]             = jsonEncoderOf[F, A]
+  implicit def circeEntityDecoder[F[_]: Concurrent, A: Decoder]: EntityDecoder[F, A] = jsonOf[F, A]
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/EnrichedStatus.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/EnrichedStatus.scala
@@ -1,18 +1,18 @@
 package com.goyeau.kubernetes.client.util
 
 import cats.implicits._
-import cats.effect.Sync
+import cats.effect.Async
 import io.k8s.apimachinery.pkg.apis.meta.v1
 import org.http4s._
 import org.http4s.circe.CirceEntityCodec._
 
 private[client] object EnrichedStatus {
-  def apply[F[_]: Sync](response: Response[F]): F[Status] =
-    if (response.status.isSuccess) Sync[F].delay(response.status)
+  def apply[F[_]](response: Response[F])(implicit F: Async[F]): F[Status] =
+    if (response.status.isSuccess) F.delay(response.status)
     else
       for {
         reasonDecoded <- EntityDecoder[F, v1.Status].decode(response, strict = false).value
-        reason        <- Sync[F].fromEither(reasonDecoded)
+        reason        <- F.fromEither(reasonDecoded)
       } yield response.status.withReason(
         s"${response.status.reason}${reason.message.map(message => s": $message").mkString}"
       )

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
@@ -41,7 +41,7 @@ object SslContexts {
       val privateKey = new JcaPEMKeyConverter().setProvider("BC").getPrivateKey(pemKeyPair.getPrivateKeyInfo)
 
       val certificateFactory = CertificateFactory.getInstance("X509")
-      val certificate        = certificateFactory.generateCertificate(certStream).asInstanceOf[X509Certificate] // scalafix:ok
+      val certificate = certificateFactory.generateCertificate(certStream).asInstanceOf[X509Certificate] // scalafix:ok
 
       defaultKeyStore.setKeyEntry(
         certificate.getSubjectX500Principal.getName,
@@ -74,7 +74,7 @@ object SslContexts {
 
     certDataStream.orElse(certFileStream).foreach { certStream =>
       val certificateFactory = CertificateFactory.getInstance("X509")
-      val certificate        = certificateFactory.generateCertificate(certStream).asInstanceOf[X509Certificate] // scalafix:ok
+      val certificate = certificateFactory.generateCertificate(certStream).asInstanceOf[X509Certificate] // scalafix:ok
       defaultTrustStore.setCertificateEntry(certificate.getSubjectX500Principal.getName, certificate)
     }
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ConfigMapsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ConfigMapsApiTest.scala
@@ -19,9 +19,9 @@ class ConfigMapsApiTest
     with WatchableTests[IO, ConfigMap]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[ConfigMap].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[ConfigMap].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.configMaps
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ContextProvider.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ContextProvider.scala
@@ -1,11 +1,22 @@
 package com.goyeau.kubernetes.client.api
 
 import cats.Parallel
-import cats.effect.{ContextShift, IO, Timer}
-import scala.concurrent.ExecutionContext
+import cats.effect.std.Dispatcher
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Resource}
+
+import scala.concurrent.duration.DurationInt
 
 trait ContextProvider {
-  implicit lazy val timer: Timer[IO]               = IO.timer(ExecutionContext.global)
-  implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-  implicit lazy val parallel: Parallel[IO]         = IO.ioParallel
+
+  private val dispatcher: Resource[IO, Dispatcher[IO]] = Dispatcher[IO]
+  private val runTimeout                               = 1.minute
+
+  def unsafeRunSync[A](f: IO[A]): A =
+    dispatcher
+      .use(d => IO.blocking(d.unsafeRunSync(f)))
+      .unsafeRunTimed(runTimeout)
+      .getOrElse(sys.error(s"IO execution timeout after $runTimeout"))
+
+  implicit lazy val parallel: Parallel[IO] = IO.parallelForIO
 }

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CronJobsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CronJobsApiTest.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.{ConcurrentEffect, IO}
+import cats.effect.{Async, IO}
 import com.goyeau.kubernetes.client.operation._
 import com.goyeau.kubernetes.client.KubernetesClient
 import org.typelevel.log4cats.Logger
@@ -22,9 +22,9 @@ class CronJobsApiTest
     with WatchableTests[IO, CronJob]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[CronJob].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[CronJob].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.cronJobs
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourcesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourcesApiTest.scala
@@ -14,6 +14,7 @@ import io.circe.generic.semiauto._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
 import org.http4s.Status
+import cats.effect.unsafe.implicits.global
 
 case class CronTab(cronSpec: String, image: String, replicas: Int)
 object CronTab {
@@ -41,12 +42,12 @@ class CustomResourcesApiTest
     with WatchableTests[IO, CronTabResource]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[CronTab].getSimpleName
-  val kind                                  = s"${classOf[CronTab].getSimpleName}"
-  val context                               = CrdContext(group, "v1", plural(resourceName))
-  val cronSpec                              = "* * * * * *"
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[CronTab].getSimpleName
+  val kind                             = s"${classOf[CronTab].getSimpleName}"
+  val context                          = CrdContext(group, "v1", plural(resourceName))
+  val cronSpec                         = "* * * * * *"
 
   override def api(implicit client: KubernetesClient[IO]) = client.customResources[CronTab, CronTabStatus](context)
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/DeploymentsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/DeploymentsApiTest.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.{ConcurrentEffect, IO}
+import cats.effect.{Async, IO}
 import com.goyeau.kubernetes.client.operation._
 import com.goyeau.kubernetes.client.{IntValue, KubernetesClient, StringValue}
 import org.typelevel.log4cats.Logger
@@ -21,9 +21,9 @@ class DeploymentsApiTest
     with WatchableTests[IO, Deployment]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[Deployment].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[Deployment].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.deployments
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
@@ -5,7 +5,12 @@ import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import io.k8s.api.autoscaling.v1.{CrossVersionObjectReference, HorizontalPodAutoscaler, HorizontalPodAutoscalerList, HorizontalPodAutoscalerSpec}
+import io.k8s.api.autoscaling.v1.{
+  CrossVersionObjectReference,
+  HorizontalPodAutoscaler,
+  HorizontalPodAutoscalerList,
+  HorizontalPodAutoscalerSpec
+}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
 
@@ -19,9 +24,9 @@ class HorizontalPodAutoscalersApiTest
     with WatchableTests[IO, HorizontalPodAutoscaler]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[HorizontalPodAutoscaler].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[HorizontalPodAutoscaler].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.horizontalPodAutoscalers
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/IngressesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/IngressesApiTest.scala
@@ -19,9 +19,9 @@ class IngressesApiTest
     with WatchableTests[IO, Ingress]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[Ingress].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[Ingress].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.ingresses
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/JobsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/JobsApiTest.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.{ConcurrentEffect, IO}
+import cats.effect.{Async, IO}
 import com.goyeau.kubernetes.client.operation._
 import com.goyeau.kubernetes.client.KubernetesClient
 import org.typelevel.log4cats.Logger
@@ -21,9 +21,9 @@ class JobsApiTest
     with WatchableTests[IO, Job]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName: String = classOf[Job].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName: String        = classOf[Job].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]): JobsApi[IO] = client.jobs
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]): NamespacedJobsApi[IO] =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ReplicaSetsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ReplicaSetsApiTest.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.{ConcurrentEffect, IO}
+import cats.effect.{Async, IO}
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
 import org.typelevel.log4cats.Logger
@@ -21,9 +21,9 @@ class ReplicaSetsApiTest
     with WatchableTests[IO, ReplicaSet]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[ReplicaSet].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[ReplicaSet].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.replicaSets
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
@@ -1,15 +1,17 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.{ConcurrentEffect, IO}
+import cats.effect.{Async, IO}
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.{Secret, SecretList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+
 import java.util.Base64
 import munit.FunSuite
 import org.http4s.Status
+
 import scala.collection.compat._
 
 class SecretsApiTest
@@ -22,9 +24,9 @@ class SecretsApiTest
     with WatchableTests[IO, Secret]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[Secret].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[Secret].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.secrets
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServiceAccountsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServiceAccountsApiTest.scala
@@ -19,9 +19,9 @@ class ServiceAccountsApiTest
     with WatchableTests[IO, ServiceAccount]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[ServiceAccount].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[ServiceAccount].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.serviceAccounts
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServicesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServicesApiTest.scala
@@ -3,11 +3,11 @@ package com.goyeau.kubernetes.client.api
 import cats.effect._
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1._
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 class ServicesApiTest
     extends FunSuite
@@ -19,9 +19,9 @@ class ServicesApiTest
     with WatchableTests[IO, Service]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[Service].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[Service].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.services
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/StatefulSetsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/StatefulSetsApiTest.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.{ConcurrentEffect, IO}
+import cats.effect.{Async, IO}
 import com.goyeau.kubernetes.client.KubernetesClient
 import com.goyeau.kubernetes.client.operation._
 import org.typelevel.log4cats.Logger
@@ -21,9 +21,9 @@ class StatefulSetsApiTest
     with WatchableTests[IO, StatefulSet]
     with ContextProvider {
 
-  implicit lazy val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
-  implicit lazy val logger: Logger[IO]      = Slf4jLogger.getLogger[IO]
-  lazy val resourceName                     = classOf[StatefulSet].getSimpleName
+  implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  lazy val resourceName                = classOf[StatefulSet].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]) = client.statefulSets
   override def namespacedApi(namespaceName: String)(implicit client: KubernetesClient[IO]) =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/ListableTests.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/ListableTests.scala
@@ -80,13 +80,12 @@ trait ListableTests[F[
         namespaceResourceNames <- Applicative[F].pure(
           (0 to 1).map(i => (s"${resourceName.toLowerCase}-$i", s"list-all-${resourceName.toLowerCase}-$i")).toSet
         )
-        _ <- namespaceResourceNames.toList.traverse {
-          case (namespaceName, resourceName) =>
-            NamespacesApiTest.createChecked[F](namespaceName) *> createChecked(namespaceName, resourceName)
+        _ <- namespaceResourceNames.toList.traverse { case (namespaceName, resourceName) =>
+          NamespacesApiTest.createChecked[F](namespaceName) *> createChecked(namespaceName, resourceName)
         }
         _ <- listAllContains(namespaceResourceNames.map(_._2))
-        _ <- namespaceResourceNames.toList.traverse {
-          case (namespaceName, _) => client.namespaces.delete(namespaceName)
+        _ <- namespaceResourceNames.toList.traverse { case (namespaceName, _) =>
+          client.namespaces.delete(namespaceName)
         }
       } yield ()
     }

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/WatchableTests.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/WatchableTests.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.operation
 
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import cats.implicits._
 import cats.{Applicative, Parallel}
 import com.goyeau.kubernetes.client.Utils.retry
@@ -92,7 +92,7 @@ trait WatchableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }]
 
       (
         watchEvents,
-        timer.sleep(100.millis) *> sendEvents
+        F.sleep(100.millis) *> sendEvents
       ).parSequence
     }
   }

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -12,8 +12,8 @@ object Dependencies {
   }
 
   lazy val http4s = {
-    val version = "0.22.0-RC1"
-    val jdkClientVersion = "0.4.0-RC1"
+    val version = "0.23.0"
+    val jdkClientVersion = "0.5.0"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",
       ivy"org.http4s::http4s-circe:$version",
@@ -27,5 +27,5 @@ object Dependencies {
 
   lazy val collectionCompat = Agg(ivy"org.scala-lang.modules::scala-collection-compat:2.4.4")
 
-  lazy val logging = Agg(ivy"org.typelevel::log4cats-slf4j:1.3.1")
+  lazy val logging = Agg(ivy"org.typelevel::log4cats-slf4j:2.1.1")
 }


### PR DESCRIPTION
 - upgrade to latest stable http4s, http4s-jdk-http-client and log4cats versions.
- http4s-circe is now requiring Cats-Effect Concurrent to decode JSON. Thus, Async is used to summon both Sync and Concurrent by one type class
- Timer and ContexShift are gone in CE 3
- Dispatcher is used to run IOs in tests