### PR TITLE
Watch in all namespaces

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ConfigMapsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ConfigMapsApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class ConfigMapsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[ConfigMapList],
-    encoder: Encoder[ConfigMap],
-    decoder: Decoder[ConfigMap]
-) extends Listable[F, ConfigMapList] {
+    val resourceDecoder: Decoder[ConfigMap],
+    encoder: Encoder[ConfigMap]
+) extends Listable[F, ConfigMapList]
+    with Watchable[F, ConfigMap] {
   val resourceUri: Uri = uri"/api" / "v1" / "configmaps"
 
   def namespace(namespace: String): NamespacedConfigMapsApi[F] =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CronJobsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CronJobsApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class CronJobsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[CronJobList],
-    encoder: Encoder[CronJob],
-    decoder: Decoder[CronJob]
-) extends Listable[F, CronJobList] {
+    val resourceDecoder: Decoder[CronJob],
+    encoder: Encoder[CronJob]
+) extends Listable[F, CronJobList]
+    with Watchable[F, CronJob] {
   val resourceUri: Uri = uri"/apis" / "batch" / "v1beta1" / "cronjobs"
 
   def namespace(namespace: String): NamespacedCronJobsApi[F] = new NamespacedCronJobsApi(httpClient, config, namespace)

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourcesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourcesApi.scala
@@ -19,9 +19,10 @@ private[client] class CustomResourcesApi[F[_], A, B](
 )(implicit
     val F: Async[F],
     val listDecoder: Decoder[CustomResourceList[A, B]],
-    encoder: Encoder[CustomResource[A, B]],
-    decoder: Decoder[CustomResource[A, B]]
-) extends Listable[F, CustomResourceList[A, B]] {
+    val resourceDecoder: Decoder[CustomResource[A, B]],
+    encoder: Encoder[CustomResource[A, B]]
+) extends Listable[F, CustomResourceList[A, B]]
+    with Watchable[F, CustomResource[A, B]] {
 
   val resourceUri: Uri = uri"/apis" / context.group / context.version / context.plural
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/DeploymentsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/DeploymentsApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class DeploymentsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[DeploymentList],
-    encoder: Encoder[Deployment],
-    decoder: Decoder[Deployment]
-) extends Listable[F, DeploymentList] {
+    val resourceDecoder: Decoder[Deployment],
+    encoder: Encoder[Deployment]
+) extends Listable[F, DeploymentList]
+    with Watchable[F, Deployment] {
   val resourceUri: Uri = uri"/apis" / "apps" / "v1" / "deployments"
 
   def namespace(namespace: String): NamespacedDeploymentsApi[F] =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class HorizontalPodAutoscalersApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[HorizontalPodAutoscalerList],
-    encoder: Encoder[HorizontalPodAutoscaler],
-    decoder: Decoder[HorizontalPodAutoscaler]
-) extends Listable[F, HorizontalPodAutoscalerList] {
+    val resourceDecoder: Decoder[HorizontalPodAutoscaler],
+    encoder: Encoder[HorizontalPodAutoscaler]
+) extends Listable[F, HorizontalPodAutoscalerList]
+    with Watchable[F, HorizontalPodAutoscaler] {
   val resourceUri: Uri = uri"/apis" / "autoscaling" / "v1" / "horizontalpodautoscalers"
 
   def namespace(namespace: String): NamespacedHorizontalPodAutoscalersApi[F] =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/IngressesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/IngressesApi.scala
@@ -4,17 +4,18 @@ import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
+import io.k8s.api.networking.v1beta1.{Ingress, IngressList}
 import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.implicits._
-import io.k8s.api.networking.v1beta1.{Ingress, IngressList}
 
 private[client] class IngressessApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[IngressList],
-    encoder: Encoder[Ingress],
-    decoder: Decoder[Ingress]
-) extends Listable[F, IngressList] {
+    val resourceDecoder: Decoder[Ingress],
+    encoder: Encoder[Ingress]
+) extends Listable[F, IngressList]
+    with Watchable[F, Ingress] {
   val resourceUri: Uri = uri"/apis" / "extensions" / "v1beta1" / "ingresses"
 
   def namespace(namespace: String): NamespacedIngressesApi[F] =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/JobsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/JobsApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class JobsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[JobList],
-    encoder: Encoder[Job],
-    decoder: Decoder[Job]
-) extends Listable[F, JobList] {
+    val resourceDecoder: Decoder[Job],
+    encoder: Encoder[Job]
+) extends Listable[F, JobList]
+    with Watchable[F, Job] {
   val resourceUri: Uri = uri"/apis" / "batch" / "v1" / "jobs"
 
   def namespace(namespace: String): NamespacedJobsApi[F] = new NamespacedJobsApi(httpClient, config, namespace)

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodDisruptionBudgetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodDisruptionBudgetsApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class PodDisruptionBudgetsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[PodDisruptionBudgetList],
-    encoder: Encoder[PodDisruptionBudget],
-    decoder: Decoder[PodDisruptionBudget]
-) extends Listable[F, PodDisruptionBudgetList] {
+    val resourceDecoder: Decoder[PodDisruptionBudget],
+    encoder: Encoder[PodDisruptionBudget]
+) extends Listable[F, PodDisruptionBudgetList]
+    with Watchable[F, PodDisruptionBudget] {
   val resourceUri: Uri = uri"/apis" / "policy" / "v1beta1" / "poddisruptionbudgets"
 
   def namespace(namespace: String): NamespacedPodDisruptionBudgetApi[F] =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -13,17 +13,18 @@ import io.k8s.api.core.v1.{Pod, PodList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.Status
 import org.http4s._
 import org.http4s.client.Client
-import org.http4s.jdkhttpclient._
 import org.http4s.implicits._
-import scodec.bits.ByteVector
+import org.http4s.jdkhttpclient._
 import org.typelevel.ci.CIString
+import scodec.bits.ByteVector
 
 private[client] class PodsApi[F[_]](val httpClient: Client[F], wsClient: WSClient[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[PodList],
-    encoder: Encoder[Pod],
-    decoder: Decoder[Pod]
-) extends Listable[F, PodList] {
+    val resourceDecoder: Decoder[Pod],
+    encoder: Encoder[Pod]
+) extends Listable[F, PodList]
+    with Watchable[F, Pod] {
   val resourceUri: Uri = uri"/api" / "v1" / "pods"
 
   def namespace(namespace: String): NamespacedPodsApi[F] =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ReplicaSetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ReplicaSetsApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class ReplicaSetsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[ReplicaSetList],
-    encoder: Encoder[ReplicaSet],
-    decoder: Decoder[ReplicaSet]
-) extends Listable[F, ReplicaSetList] {
+    val resourceDecoder: Decoder[ReplicaSet],
+    encoder: Encoder[ReplicaSet]
+) extends Listable[F, ReplicaSetList]
+    with Watchable[F, ReplicaSet] {
   val resourceUri: Uri = uri"/apis" / "apps" / "v1" / "replicasets"
 
   def namespace(namespace: String): NamespacedReplicaSetsApi[F] =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/SecretsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/SecretsApi.scala
@@ -1,22 +1,24 @@
 package com.goyeau.kubernetes.client.api
 
-import java.util.Base64
 import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation._
 import io.circe._
 import io.k8s.api.core.v1.{Secret, SecretList}
-import org.http4s.{Status, Uri}
 import org.http4s.client.Client
 import org.http4s.implicits._
+import org.http4s.{Status, Uri}
+
+import java.util.Base64
 import scala.collection.compat._
 
 private[client] class SecretsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[SecretList],
-    encoder: Encoder[Secret],
-    decoder: Decoder[Secret]
-) extends Listable[F, SecretList] {
+    val resourceDecoder: Decoder[Secret],
+    encoder: Encoder[Secret]
+) extends Listable[F, SecretList]
+    with Watchable[F, Secret] {
   val resourceUri = uri"/api" / "v1" / "secrets"
 
   def namespace(namespace: String) = new NamespacedSecretsApi(httpClient, config, namespace)

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServiceAccountsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServiceAccountsApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class ServiceAccountsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[ServiceAccountList],
-    encoder: Encoder[ServiceAccount],
-    decoder: Decoder[ServiceAccount]
-) extends Listable[F, ServiceAccountList] {
+    val resourceDecoder: Decoder[ServiceAccount],
+    encoder: Encoder[ServiceAccount]
+) extends Listable[F, ServiceAccountList]
+    with Watchable[F, ServiceAccount] {
   val resourceUri: Uri = uri"/api" / "v1" / "serviceaccounts"
 
   def namespace(namespace: String): NamespacedServiceAccountsApi[F] =

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServicesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServicesApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class ServicesApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[ServiceList],
-    encoder: Encoder[Service],
-    decoder: Decoder[Service]
-) extends Listable[F, ServiceList] {
+    val resourceDecoder: Decoder[Service],
+    encoder: Encoder[Service]
+) extends Listable[F, ServiceList]
+    with Watchable[F, Service] {
   val resourceUri: Uri = uri"/api" / "v1" / "services"
 
   def namespace(namespace: String): NamespacedServicesApi[F] = new NamespacedServicesApi(httpClient, config, namespace)

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/StatefulSetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/StatefulSetsApi.scala
@@ -12,9 +12,10 @@ import org.http4s.implicits._
 private[client] class StatefulSetsApi[F[_]](val httpClient: Client[F], val config: KubeConfig)(implicit
     val F: Async[F],
     val listDecoder: Decoder[StatefulSetList],
-    encoder: Encoder[StatefulSet],
-    decoder: Decoder[StatefulSet]
-) extends Listable[F, StatefulSetList] {
+    val resourceDecoder: Decoder[StatefulSet],
+    encoder: Encoder[StatefulSet]
+) extends Listable[F, StatefulSetList]
+    with Watchable[F, StatefulSet] {
   val resourceUri: Uri = uri"/apis" / "apps" / "v1" / "statefulsets"
 
   def namespace(namespace: String): NamespacedStatefulSetsApi[F] =

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ContextProvider.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ContextProvider.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.DurationInt
 trait ContextProvider {
 
   private val dispatcher: Resource[IO, Dispatcher[IO]] = Dispatcher[IO]
-  private val runTimeout                               = 1.minute
+  private val runTimeout                               = 90.seconds
 
   def unsafeRunSync[A](f: IO[A]): A =
     dispatcher


### PR DESCRIPTION
Watch resources in all namespaces. Almost all APIs now support the watch operation without namespace parameter.