### PR TITLE
Fix uri building for `Proxy`

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Proxy.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Proxy.scala
@@ -24,8 +24,7 @@ private[client] trait Proxy[F[_]] {
     httpClient.expect[String](
       Request(
         method,
-        //TODO: I think this is wrong (hamnis)
-        config.server.resolve(resourceUri) / name / s"proxy$path",
+        (config.server.resolve(resourceUri) / name / "proxy").addPath(path.toRelative.renderString),
         headers = Headers(config.authorization.toList),
         body = data.fold[EntityBody[F]](EmptyBody)(
           implicitly[EntityEncoder[F, String]].withContentType(contentType).toEntity(_).body


### PR DESCRIPTION
Building uri as `"uri" / s"proxy$path"` will lead to `uri/proxy%2Fpath`, looks like expected a `uri/proxy/path`. See scastie https://scastie.scala-lang.org/wMDOxAFKSWuqoHafM5GgYQ