### PR TITLE
Update Circe to 0.14.1 and Http4s to 0.23.3

### DIFF
--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -3,7 +3,7 @@ import mill.scalalib._
 
 object Dependencies {
   lazy val circe = {
-    val version = "0.13.0"
+    val version = "0.14.1"
     Agg(
       ivy"io.circe::circe-core:$version",
       ivy"io.circe::circe-generic:$version",
@@ -12,7 +12,7 @@ object Dependencies {
   }
 
   lazy val http4s = {
-    val version = "0.23.0"
+    val version = "0.23.3"
     val jdkClientVersion = "0.5.0"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",


### PR DESCRIPTION
I've found that my application which depends on both kubernetes-client and http4s fails in runtime after update of kubernetes-client to 0.7.0 because http4s 0.23.0+ depends on circe 0.14.1 whereas  kubernetes-client 0.7.0 still depends on 0.13.0