### PR TITLE
http4s v1 version

### DIFF
--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -12,8 +12,8 @@ object Dependencies {
   }
 
   lazy val http4s = {
-    val version          = "0.23.3"
-    val jdkClientVersion = "0.5.0"
+    val version          = "1.0.0-M27"
+    val jdkClientVersion = "0.6.0-M4"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",
       ivy"org.http4s::http4s-circe:$version",


### PR DESCRIPTION
I had in mind to use `M26` instead, since that's supposed to be matching `0.23.3` according to https://http4s.org/changelog/#v1-0-0-m26-2021-09-02 but that is not published somehow, so I have chosen `M27` instead.

TODO:
- target another branch than master 
- publish using another artifact (not sure how that's done in mill)