### PR TITLE
Cross compile for scala 3 with cats effect 2

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -9,9 +9,10 @@ import com.goyeau.mill.scalafix.StyleModule
 import io.github.davidgregory084.TpolecatModule
 import mill._
 import mill.scalalib._
+import mill.scalalib.api.Util.isScala3
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 
-object `kubernetes-client` extends Cross[KubernetesClientModule]("2.13.4", "2.12.12")
+object `kubernetes-client` extends Cross[KubernetesClientModule]("3.0.1", "2.13.5", "2.12.12")
 class KubernetesClientModule(val crossScalaVersion: String)
     extends CrossScalaModule
     with TpolecatModule
@@ -19,10 +20,16 @@ class KubernetesClientModule(val crossScalaVersion: String)
     with GitVersionedPublishModule
     with SwaggerModelGenerator {
 
-  override def scalacOptions = super.scalacOptions().filter(_ != "-Wunused:imports")
+  override def scalacOptions =
+    super.scalacOptions()
+      .filter(_ != "-Wunused:imports")
+      .filter(_ != "-Xfatal-warnings") ++
+      (if (isScala3(scalaVersion())) Seq("-language:Scala2", "-Xmax-inlines", "50") else Seq.empty) ++ Seq("-Ywarn-unused")
+
   override def ivyDeps =
     super.ivyDeps() ++ http4s ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging
-  override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Agg(ivy"org.typelevel:::kind-projector:0.11.3")
+  override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++
+    (if (isScala3(scalaVersion())) Agg.empty else Agg(ivy"org.typelevel:::kind-projector:0.11.3"))
 
   object test extends Tests {
     def testFrameworks    = Seq("munit.Framework")

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -3,7 +3,7 @@ import mill.scalalib._
 
 object Dependencies {
   lazy val circe = {
-    val version = "0.13.0"
+    val version = "0.14.1"
     Agg(
       ivy"io.circe::circe-core:$version",
       ivy"io.circe::circe-generic:$version",
@@ -12,8 +12,8 @@ object Dependencies {
   }
 
   lazy val http4s = {
-    val version = "0.22.0-RC1"
-    val jdkClientVersion = "0.4.0-RC1"
+    val version = "0.22.11"
+    val jdkClientVersion = "0.4.0"
     Agg(
       ivy"org.http4s::http4s-dsl:$version",
       ivy"org.http4s::http4s-circe:$version",
@@ -27,5 +27,7 @@ object Dependencies {
 
   lazy val collectionCompat = Agg(ivy"org.scala-lang.modules::scala-collection-compat:2.4.4")
 
-  lazy val logging = Agg(ivy"org.typelevel::log4cats-slf4j:1.3.1")
+  lazy val logging = Agg(ivy"org.typelevel::log4cats-slf4j:2.1.1")
+
+  lazy val logback = Agg(ivy"ch.qos.logback:logback-classic:1.2.3")
 }


### PR DESCRIPTION
I'm keen to use this client in a new project I'm working on but unfortunately we've got some internal libraries that are still stuck on CE 2 (blocked by monix) at this stage. 

I've attempted to apply the changes to cross compile but my local mill set up doesn't appear to be working so I'm not sure if I've made all the necessary changes for this.
Wanted to raise a PR and see the viability of cross compiling v0.6.0 to scala 3 so that I can use it in the meantime until it's unblocked.
(Not looking to merge into master but perhaps a new branch for CE2?)