### PR TITLE
Support multiple ca certs for trust manager

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
@@ -77,7 +77,7 @@ object SslContexts {
       val certificateFactory = CertificateFactory.getInstance("X509")
       val certificates       = certificateFactory.generateCertificates(certStream).asScala
       certificates
-        .map(_.asInstanceOf[X509Certificate])
+        .map(_.asInstanceOf[X509Certificate]) // scalafix:ok
         .zipWithIndex
         .foreach { case (certificate, i) =>
           val alias = s"${certificate.getSubjectX500Principal.getName}-$i"

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
@@ -9,6 +9,7 @@ import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
 import org.bouncycastle.openssl.{PEMKeyPair, PEMParser}
+import scala.jdk.CollectionConverters.*
 
 object SslContexts {
   private val TrustStoreSystemProperty         = "javax.net.ssl.trustStore"
@@ -74,8 +75,14 @@ object SslContexts {
 
     certDataStream.orElse(certFileStream).foreach { certStream =>
       val certificateFactory = CertificateFactory.getInstance("X509")
-      val certificate = certificateFactory.generateCertificate(certStream).asInstanceOf[X509Certificate] // scalafix:ok
-      defaultTrustStore.setCertificateEntry(certificate.getSubjectX500Principal.getName, certificate)
+      val certificates       = certificateFactory.generateCertificates(certStream).asScala
+      certificates
+        .map(_.asInstanceOf[X509Certificate])
+        .zipWithIndex
+        .foreach { case (certificate, i) =>
+          val alias = s"${certificate.getSubjectX500Principal.getName}-$i"
+          defaultTrustStore.setCertificateEntry(alias, certificate)
+        }
     }
 
     val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)


### PR DESCRIPTION
- Code currently assumes there's only one certificate in the file causing the server request to get rejected. Comparing to the official java client, the equivalent code allows for more than one certificate in the file. 
Updated the implementation to match: https://github.com/kubernetes-client/java/blob/v13.0.2/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java#L1328-L1332