### PR TITLE
Upgraded to the jdk client version 0.10.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -31,7 +31,7 @@ trait KubernetesClientModule
   )
 
   override def ivyDeps =
-    super.ivyDeps() ++ http4s ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging ++ java8compat
+    super.ivyDeps() ++ fs2 ++ http4s ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging ++ java8compat
   override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++
     (if (isScala3(scalaVersion())) Agg.empty else Agg(ivy"org.typelevel:::kind-projector:0.13.3"))
 

--- a/build.sc
+++ b/build.sc
@@ -31,7 +31,7 @@ trait KubernetesClientModule
   )
 
   override def ivyDeps =
-    super.ivyDeps() ++ fs2 ++ http4s ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging ++ java8compat
+    super.ivyDeps() ++ http4s ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging ++ java8compat
   override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++
     (if (isScala3(scalaVersion())) Agg.empty else Agg(ivy"org.typelevel:::kind-projector:0.13.3"))
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -10,7 +10,8 @@ import com.goyeau.kubernetes.client.util.cache.{AuthorizationParse, ExecToken}
 import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient, WSClient}
+import org.http4s.client.websocket.WSClient
+import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient}
 import org.typelevel.log4cats.Logger
 
 import java.net.http.HttpClient
@@ -72,8 +73,8 @@ object KubernetesClient {
       client <- Resource.eval {
         Sync[F].delay(HttpClient.newBuilder().sslContext(SslContexts.fromConfig(config)).build())
       }
-      httpClient <- JdkHttpClient[F](client)
-      wsClient   <- JdkWSClient[F](client)
+      httpClient = JdkHttpClient[F](client)
+      wsClient   = JdkWSClient[F](client)
       authorization <- Resource.eval {
         OptionT
           .fromOption(config.authorization)

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -5,15 +5,16 @@ import cats.data.OptionT
 import cats.effect.*
 import com.goyeau.kubernetes.client.api.*
 import com.goyeau.kubernetes.client.crd.{CrdContext, CustomResource, CustomResourceList}
+import com.goyeau.kubernetes.client.operation.*
 import com.goyeau.kubernetes.client.util.SslContexts
 import com.goyeau.kubernetes.client.util.cache.{AuthorizationParse, ExecToken}
 import io.circe.{Decoder, Encoder}
+import org.http4s.Request
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
 import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient}
-import org.http4s.client.websocket.WSClient
+import org.http4s.client.websocket.{WSClient, WSRequest}
 import org.typelevel.log4cats.Logger
-
 import java.net.http.HttpClient
 
 class KubernetesClient[F[_]: Async: Logger](

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -9,10 +9,9 @@ import com.goyeau.kubernetes.client.util.SslContexts
 import com.goyeau.kubernetes.client.util.cache.{AuthorizationParse, ExecToken}
 import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
-import org.http4s.client.middleware.{RequestLogger, ResponseLogger}
 import org.http4s.headers.Authorization
 import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient}
-import org.http4s.client.websocket.{WSClient, WSClientHighLevel, WSConnection, WSConnectionHighLevel, WSRequest}
+import org.http4s.client.websocket.WSClient
 import org.typelevel.log4cats.Logger
 
 import java.net.http.HttpClient

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -66,26 +66,6 @@ class KubernetesClient[F[_]: Async: Logger](
       encoder: Encoder[CustomResource[A, B]],
       decoder: Decoder[CustomResource[A, B]]
   ) = new CustomResourcesApi[F, A, B](httpClient, config, authorization, context)
-
-  def customRequest(
-      request: Request[F]
-  ): F[Request[F]] =
-    Request[F](
-      method = request.method,
-      uri = config.server.resolve(request.uri),
-      httpVersion = request.httpVersion,
-      headers = request.headers,
-      body = request.body,
-      attributes = request.attributes
-    ).withOptionalAuthorization(authorization)
-
-  def customRequest(request: WSRequest): F[WSRequest] =
-    WSRequest(
-      uri = config.server.resolve(request.uri),
-      headers = request.headers,
-      method = request.method
-    ).withOptionalAuthorization(authorization)
-
 }
 
 object KubernetesClient {

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client.api
 
-import cats.effect.{Async, Resource}
+import cats.effect.Async
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
 import com.goyeau.kubernetes.client.KubeConfig

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -18,13 +18,16 @@ import org.http4s.*
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
 import org.http4s.implicits.*
-import org.http4s.jdkhttpclient.*
+import org.http4s.client.websocket.WSClient
+import org.http4s.client.websocket.WSRequest
 import org.typelevel.ci.CIString
 import org.typelevel.log4cats.Logger
 import scodec.bits.ByteVector
 
 import java.nio.file.Path as JPath
 import scala.concurrent.duration.DurationInt
+import org.http4s.client.websocket.WSFrame
+import org.http4s.client.websocket.WSDataFrame
 
 private[client] class PodsApi[F[_]: Logger](
     val httpClient: Client[F],
@@ -113,13 +116,11 @@ private[client] class NamespacedPodsApi[F[_]](
       ("container" -> container) ++?
       ("command"   -> commands)
 
-    WSRequest(uri, method = Method.POST)
+    WSRequest(uri, Headers.empty, Method.POST)
       .withOptionalAuthorization(authorization)
-      .map { r =>
-        r.copy(
-          headers = r.headers.put(Header.Raw(CIString("Sec-WebSocket-Protocol"), "v4.channel.k8s.io"))
-        )
-      }
+      .map(r =>
+        r.withHeaders(headers = r.headers.put(Header.Raw(CIString("Sec-WebSocket-Protocol"), "v4.channel.k8s.io")))
+      )
   }
 
   @deprecated("Use download() which uses fs2.io.file.Path", "0.8.2")

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -1,6 +1,7 @@
 package com.goyeau.kubernetes.client.api
 
 import cats.effect.{Async, Resource}
+import cats.effect.syntax.all.*
 import cats.syntax.all.*
 import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.api.ExecRouting.*
@@ -142,24 +143,19 @@ private[client] class NamespacedPodsApi[F[_]](
       F.ref(List.empty[StdErr]),
       F.ref(none[ErrorOrStatus])
     ).tupled.flatMap { case (stdErr, errorOrStatus) =>
-      execRequest(podName, Seq("sh", "-c", s"cat ${sourceFile.toString}"), container).flatMap { request =>
-        wsClient.connectHighLevel(request).use { connection =>
-          connection.receiveStream
-            .through(processWebSocketData)
-            .evalMapFilter[F, Chunk[Byte]] {
-              case Left(StdOut(data))   => Chunk.array(data).some.pure[F]
-              case Left(e: StdErr)      => stdErr.update(e :: _).as(None)
-              case Right(statusOrError) => errorOrStatus.update(_.orElse(statusOrError.some)).as(None)
-            }
-            .unchunks
-            .through(Files[F].writeAll(destinationFile))
-            .compile
-            .drain
-            .flatMap { _ =>
-              (stdErr.get.map(_.reverse), errorOrStatus.get).tupled
-            }
+      execStream(podName, container, Seq("sh", "-c", s"cat ${sourceFile.toString}"))
+        .evalMapFilter[F, Chunk[Byte]] {
+          case Left(StdOut(data))   => Chunk.array(data).some.pure[F]
+          case Left(e: StdErr)      => stdErr.update(e :: _).as(None)
+          case Right(statusOrError) => errorOrStatus.update(_.orElse(statusOrError.some)).as(None)
         }
-      }
+        .unchunks
+        .through(Files[F].writeAll(destinationFile))
+        .compile
+        .drain
+        .flatMap { _ =>
+          (stdErr.get.map(_.reverse), errorOrStatus.get).tupled
+        }
     }
 
   @deprecated("Use upload() which uses fs2.io.file.Path", "0.8.2")
@@ -179,16 +175,7 @@ private[client] class NamespacedPodsApi[F[_]](
   ): F[(List[StdErr], Option[ErrorOrStatus])] = {
     val mkDirResult = destinationFile.parent match {
       case Some(dir) =>
-        execRequest(
-          podName,
-          Seq("sh", "-c", s"mkdir -p $dir"),
-          container
-        ).flatMap { mkDirRequest =>
-          wsClient
-            .connectHighLevel(mkDirRequest)
-            .map(conn => F.delay(conn.receiveStream.through(processWebSocketData)))
-            .use(_.flatMap(foldErrorStream))
-        }
+        foldErrorStream(execStream(podName, container, Seq("sh", "-c", s"mkdir -p $dir")))
       case None =>
         (List.empty -> None).pure
     }
@@ -201,37 +188,34 @@ private[client] class NamespacedPodsApi[F[_]](
     )
 
     val uploadFileResult =
-      uploadRequest.flatMap { uploadRequest =>
-        wsClient.connectHighLevel(uploadRequest).use { connection =>
-          val source = Files[F].readAll(sourceFile, 4096, Flags.Read)
-          val sendData = source
-            .mapChunks(chunk => Chunk(WSFrame.Binary(ByteVector(chunk.toChain.prepend(StdInId).toVector))))
-            .through(connection.sendPipe)
-          val retryAttempts = 5
-          val sendWithRetry = Stream
-            .retry(sendData.compile.drain, delay = 500.millis, nextDelay = _ * 2, maxAttempts = retryAttempts)
-            .onError { case e =>
-              Stream.eval(Logger[F].error(e)(s"Failed send file data after $retryAttempts attempts"))
-            }
+      uploadRequest.toResource.flatMap(wsClient.connectHighLevel).use { connection =>
+        val source = Files[F].readAll(sourceFile, 4096, Flags.Read)
+        val sendData = source
+          .mapChunks(chunk => Chunk(WSFrame.Binary(ByteVector(chunk.toChain.prepend(StdInId).toVector))))
+          .through(connection.sendPipe)
+        val retryAttempts = 5
+        val sendWithRetry = Stream
+          .retry(sendData.compile.drain, delay = 500.millis, nextDelay = _ * 2, maxAttempts = retryAttempts)
+          .onError { case e =>
+            Stream.eval(Logger[F].error(e)(s"Failed send file data after $retryAttempts attempts"))
+          }
 
-          val result = for {
-            signal <- Stream.eval(SignallingRef[F, Boolean](false))
-            dataStream = sendWithRetry *> Stream.eval(signal.set(true))
+        val result = for {
+          signal <- Stream.eval(SignallingRef[F, Boolean](false))
+          dataStream = sendWithRetry *> Stream.eval(signal.set(true))
 
-            output = connection.receiveStream
-              .through(
-                processWebSocketData
-              )
-              .interruptWhen(signal)
-              .concurrently(dataStream)
+          output = connection.receiveStream
+            .through(skipConnectionClosedErrors)
+            .through(processWebSocketData)
+            .interruptWhen(signal)
+            .concurrently(dataStream)
 
-            errors = foldErrorStream(
-              output
-            ).map { case (errors, _) => errors }
-          } yield errors
+          errors = foldErrorStream(
+            output
+          ).map { case (errors, _) => errors }
+        } yield errors
 
-          result.compile.lastOrError.flatten
-        }
+        result.compile.lastOrError.flatten
       }
 
     for {
@@ -249,12 +233,15 @@ private[client] class NamespacedPodsApi[F[_]](
       stdout: Boolean = true,
       stderr: Boolean = true,
       tty: Boolean = false
-  ): Resource[F, F[Stream[F, Either[ExecStream, ErrorOrStatus]]]] =
-    Resource.eval(execRequest(podName, command, container, stdin, stdout, stderr, tty)).flatMap { request =>
-      wsClient.connectHighLevel(request).map { connection =>
-        F.delay(connection.receiveStream.through(processWebSocketData))
+  ): Stream[F, Either[ExecStream, ErrorOrStatus]] =
+    Stream
+      .eval(execRequest(podName, command, container, stdin, stdout, stderr, tty))
+      .flatMap(request => Stream.resource(wsClient.connectHighLevel(request)))
+      .flatMap { connection =>
+        connection.receiveStream
+          .through(skipConnectionClosedErrors)
+          .through(processWebSocketData)
       }
-    }
 
   def exec(
       podName: String,
@@ -265,11 +252,26 @@ private[client] class NamespacedPodsApi[F[_]](
       stderr: Boolean = true,
       tty: Boolean = false
   ): F[(List[ExecStream], Option[ErrorOrStatus])] =
-    execStream(podName, container, command, stdin, stdout, stderr, tty).use(_.flatMap(foldStream))
+    foldStream(execStream(podName, container, command, stdin, stdout, stderr, tty))
+
+  private def skipConnectionClosedErrors: Pipe[F, WSDataFrame, WSDataFrame] =
+    _.map(_.some)
+      .recover {
+        // Need to handle (and ignore) this exception
+        //
+        // Because of the "conflict" between the http4s WS client and
+        // the underlying JDK WS client (which are both high-level clients)
+        // an extra "Close" frame gets sent to the server, potentially
+        // after the TCP connection is closed, which causes this exception.
+        //
+        // This will be solved in a later version of the http4s (core or jdk).
+        case e: java.io.IOException if e.getMessage == "closed output" => none
+      }
+      .unNone
 
   private def foldStream(
       stdoutStream: Stream[F, Either[ExecStream, ErrorOrStatus]]
-  ) =
+  ): F[(List[ExecStream], Option[ErrorOrStatus])] =
     stdoutStream.compile.fold((List.empty[ExecStream], none[ErrorOrStatus])) { case ((accEvents, accStatus), data) =>
       data match {
         case Left(event) =>
@@ -281,7 +283,7 @@ private[client] class NamespacedPodsApi[F[_]](
 
   private def foldErrorStream(
       stdoutStream: Stream[F, Either[ExecStream, ErrorOrStatus]]
-  ) =
+  ): F[(List[StdErr], Option[ErrorOrStatus])] =
     stdoutStream.compile.fold((List.empty[StdErr], none[ErrorOrStatus])) { case ((accEvents, accStatus), data) =>
       data match {
         case Left(event) =>

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
@@ -5,7 +5,7 @@ import cats.syntax.all.*
 import cats.{Applicative, FlatMap}
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.WSRequest
+import org.http4s.client.websocket.WSRequest
 import org.http4s.{EntityDecoder, Request, Response}
 
 package object operation {
@@ -21,9 +21,7 @@ package object operation {
   implicit private[client] class KubernetesWsRequestOps[F[_]: Applicative](request: WSRequest) {
     def withOptionalAuthorization(authorization: Option[F[Authorization]]): F[WSRequest] =
       authorization.fold(request.pure[F]) { authorization =>
-        authorization.map { auth =>
-          request.copy(headers = request.headers.put(auth))
-        }
+        authorization.map(auth => request.withHeaders(request.headers.put(auth)))
       }
   }
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
@@ -36,22 +36,18 @@ object SslContexts {
     val _ = for {
       keyStream  <- keyDataStream.orElse(keyFileStream)
       certStream <- certDataStream.orElse(certFileStream)
-    } yield {
-      Security.addProvider(new BouncyCastleProvider())
-      val pemKeyPair =
-        new PEMParser(new InputStreamReader(keyStream)).readObject().asInstanceOf[PEMKeyPair]
-      val privateKey = new JcaPEMKeyConverter().setProvider("BC").getPrivateKey(pemKeyPair.getPrivateKeyInfo)
+      _          = Security.addProvider(new BouncyCastleProvider())
+      pemKeyPair = new PEMParser(new InputStreamReader(keyStream)).readObject().asInstanceOf[PEMKeyPair]
+      privateKey = new JcaPEMKeyConverter().setProvider("BC").getPrivateKey(pemKeyPair.getPrivateKeyInfo)
 
-      val certificateFactory = CertificateFactory.getInstance("X509")
-      val certificate        = certificateFactory.generateCertificate(certStream).asInstanceOf[X509Certificate]
-
-      defaultKeyStore.setKeyEntry(
-        certificate.getSubjectX500Principal.getName,
-        privateKey,
-        config.clientKeyPass.fold(Array.empty[Char])(_.toCharArray),
-        Array(certificate)
-      )
-    }
+      certificateFactory = CertificateFactory.getInstance("X509")
+      certificate        = certificateFactory.generateCertificate(certStream).asInstanceOf[X509Certificate]
+    } yield defaultKeyStore.setKeyEntry(
+      certificate.getSubjectX500Principal.getName,
+      privateKey,
+      config.clientKeyPass.fold(Array.empty[Char])(_.toCharArray),
+      Array(certificate)
+    )
 
     val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     keyManagerFactory.init(defaultKeyStore, Array.empty)

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/RawApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/RawApiTest.scala
@@ -9,6 +9,7 @@ import org.http4s.{Request, Status}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
+import java.nio.file.Files as JFiles
 import org.http4s.implicits.*
 
 class RawApiTest extends FunSuite with MinikubeClientProvider[IO] with ContextProvider {

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/WatchableTests.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/WatchableTests.scala
@@ -7,7 +7,6 @@ import com.goyeau.kubernetes.client.Utils.retry
 import com.goyeau.kubernetes.client.api.CustomResourceDefinitionsApiTest
 import com.goyeau.kubernetes.client.{EventType, KubernetesClient, WatchEvent}
 import fs2.concurrent.SignallingRef
-import fs2.{Pipe, Stream}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
 import org.http4s.Status

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/WatchableTests.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/WatchableTests.scala
@@ -93,41 +93,38 @@ trait WatchableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }]
       })
     def processEvent(
         received: Ref[F, Map[String, Set[EventType]]],
-        signal: SignallingRef[F, Boolean]
-    ): Pipe[F, Either[String, WatchEvent[Resource]], Unit] =
-      _.flatMap {
+        signal: SignallingRef[F, Boolean],
+        event: Either[String, WatchEvent[Resource]]
+    ): F[Unit] =
+      event match {
         case Right(we) if isExpectedResource(we) =>
-          Stream.eval {
-            for {
-              _ <- received.update(events =>
-                we.`object`.metadata.flatMap(_.namespace) match {
-                  case Some(namespace) =>
-                    val updated = events.get(namespace) match {
-                      case Some(namespaceEvents) => namespaceEvents + we.`type`
-                      case _                     => Set(we.`type`)
-                    }
-                    events.updated(namespace, updated)
-                  case _ =>
-                    val crdNamespace = "customresourcedefinition"
-                    events.updated(crdNamespace, events.getOrElse(crdNamespace, Set.empty) + we.`type`)
-                }
-              )
-              allReceived <- received.get.map(_ == expected)
-              _           <- F.whenA(allReceived)(signal.set(true))
-            } yield ()
-          }
-        case _ => Stream.eval(F.unit)
+          for {
+            _ <- received.update(events =>
+              we.`object`.metadata.flatMap(_.namespace) match {
+                case Some(namespace) =>
+                  val updated = events.get(namespace) match {
+                    case Some(namespaceEvents) => namespaceEvents + we.`type`
+                    case _                     => Set(we.`type`)
+                  }
+                  events.updated(namespace, updated)
+                case _ =>
+                  val crdNamespace = "customresourcedefinition"
+                  events.updated(crdNamespace, events.getOrElse(crdNamespace, Set.empty) + we.`type`)
+              }
+            )
+            allReceived <- received.get.map(_ == expected)
+            _           <- F.whenA(allReceived)(signal.set(true))
+          } yield ()
+        case _ => F.unit
       }
 
     val watchEvents = for {
       signal         <- SignallingRef[F, Boolean](false)
       receivedEvents <- Ref.of(Map.empty[String, Set[EventType]])
       watchStream = watchingNamespace
-        .map(watchApi)
-        .getOrElse(api)
+        .fold(api)(watchApi)
         .watch(resourceVersion = resourceVersion)
-        .through(processEvent(receivedEvents, signal))
-        .evalMap(_ => receivedEvents.get)
+        .evalTap(processEvent(receivedEvents, signal, _))
         .interruptWhen(signal)
       _      <- watchStream.interruptAfter(60.seconds).compile.drain
       events <- receivedEvents.get

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -10,8 +10,16 @@ lazy val circe = {
   )
 }
 
-lazy val http4s = {
-  val version          = "0.23.30"
+lazy val fs2 = {
+    val version = "3.9.3"
+    Agg(
+      ivy"co.fs2::fs2-core:$version",
+      ivy"co.fs2::fs2-io:$version",
+    )
+  }
+
+  lazy val http4s = {
+    val version          = "0.23.30"
   val jdkClientVersion = "0.10.0"
   Agg(
     ivy"org.http4s::http4s-dsl:$version",

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -12,7 +12,7 @@ lazy val circe = {
 
 lazy val http4s = {
   val version          = "0.23.30"
-  val jdkClientVersion = "0.5.0"
+  val jdkClientVersion = "0.10.0"
   Agg(
     ivy"org.http4s::http4s-dsl:$version",
     ivy"org.http4s::http4s-circe:$version",

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -10,16 +10,8 @@ lazy val circe = {
   )
 }
 
-lazy val fs2 = {
-    val version = "3.9.3"
-    Agg(
-      ivy"co.fs2::fs2-core:$version",
-      ivy"co.fs2::fs2-io:$version",
-    )
-  }
-
-  lazy val http4s = {
-    val version          = "0.23.30"
+lazy val http4s = {
+  val version          = "0.23.30"
   val jdkClientVersion = "0.10.0"
   Agg(
     ivy"org.http4s::http4s-dsl:$version",


### PR DESCRIPTION
Hello!

I hope it's ok to open a PR directly without an issue first.

This PR upgrades the http4s jdk client to `0.7.0`. `0.7.0` is not binary-compatible with `0.5.0`, so this is necessary if the downstream users (me 😄 ) wish to upgrade the jdk client.

I couldn't run tests because I don't have minikube set up. I'm hoping CI will catch anything that could be a problem, although the changes themselves are very straightforward.

Let me know if there's anything else that needs to be done!