### PR TITLE
effectful authorization header

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -15,7 +15,7 @@ import java.net.http.HttpClient
 class KubernetesClient[F[_]: Async: Logger](
     httpClient: Client[F],
     wsClient: WSClient[F],
-    config: KubeConfig,
+    config: KubeConfig[F],
     cachedExecToken: Option[CachedExecToken[F]]
 ) {
   lazy val namespaces: NamespacesApi[F] = new NamespacesApi(httpClient, config, cachedExecToken)
@@ -60,7 +60,7 @@ class KubernetesClient[F[_]: Async: Logger](
 }
 
 object KubernetesClient {
-  def apply[F[_]: Async: Logger](config: KubeConfig): Resource[F, KubernetesClient[F]] =
+  def apply[F[_]: Async: Logger](config: KubeConfig[F]): Resource[F, KubernetesClient[F]] =
     for {
       client <- Resource.eval {
         Sync[F].delay(HttpClient.newBuilder().sslContext(SslContexts.fromConfig(config)).build())
@@ -75,6 +75,6 @@ object KubernetesClient {
       cachedExecToken
     )
 
-  def apply[F[_]: Async: Logger](config: F[KubeConfig]): Resource[F, KubernetesClient[F]] =
+  def apply[F[_]: Async: Logger](config: F[KubeConfig[F]]): Resource[F, KubernetesClient[F]] =
     Resource.eval(config).flatMap(apply(_))
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ConfigMapsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ConfigMapsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class ConfigMapsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class ConfigMapsApi[F[_]](
 
 private[client] class NamespacedConfigMapsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     val namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CronJobsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CronJobsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class CronJobsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class CronJobsApi[F[_]](
 
 private[client] class NamespacedCronJobsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourceDefinitionsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourceDefinitionsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class CustomResourceDefinitionsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourcesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/CustomResourcesApi.scala
@@ -14,7 +14,7 @@ import org.http4s.{Request, Status, Uri}
 
 private[client] class CustomResourcesApi[F[_], A, B](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     val context: CrdContext
 )(implicit
@@ -33,7 +33,7 @@ private[client] class CustomResourcesApi[F[_], A, B](
 
 private[client] class NamespacedCustomResourcesApi[F[_], A, B](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     val context: CrdContext,
     namespace: String

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/DeploymentsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/DeploymentsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class DeploymentsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class DeploymentsApi[F[_]](
 
 private[client] class NamespacedDeploymentsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class HorizontalPodAutoscalersApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class HorizontalPodAutoscalersApi[F[_]](
 
 private[client] class NamespacedHorizontalPodAutoscalersApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/IngressesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/IngressesApi.scala
@@ -13,7 +13,7 @@ import org.http4s.implicits.*
 
 private[client] class IngressessApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -30,7 +30,7 @@ private[client] class IngressessApi[F[_]](
 
 private[client] class NamespacedIngressesApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/JobsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/JobsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class JobsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class JobsApi[F[_]](
 
 private[client] class NamespacedJobsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/LeasesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/LeasesApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class LeasesApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -31,7 +31,7 @@ private[client] class LeasesApi[F[_]](
 
 private[client] class NamespacedLeasesApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/NamespacesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/NamespacesApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class NamespacesApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodDisruptionBudgetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodDisruptionBudgetsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class PodDisruptionBudgetsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class PodDisruptionBudgetsApi[F[_]](
 
 private[client] class NamespacedPodDisruptionBudgetApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ReplicaSetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ReplicaSetsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class ReplicaSetsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class ReplicaSetsApi[F[_]](
 
 private[client] class NamespacedReplicaSetsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/SecretsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/SecretsApi.scala
@@ -14,7 +14,7 @@ import java.util.Base64
 
 private[client] class SecretsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -30,7 +30,7 @@ private[client] class SecretsApi[F[_]](
 
 private[client] class NamespacedSecretsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServiceAccountsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServiceAccountsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class ServiceAccountsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class ServiceAccountsApi[F[_]](
 
 private[client] class NamespacedServiceAccountsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServicesApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/ServicesApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits._
 
 private[client] class ServicesApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class ServicesApi[F[_]](
 
 private[client] class NamespacedServicesApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/StatefulSetsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/StatefulSetsApi.scala
@@ -12,7 +12,7 @@ import org.http4s.implicits.*
 
 private[client] class StatefulSetsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]]
 )(implicit
     val F: Async[F],
@@ -29,7 +29,7 @@ private[client] class StatefulSetsApi[F[_]](
 
 private[client] class NamespacedStatefulSetsApi[F[_]](
     val httpClient: Client[F],
-    val config: KubeConfig,
+    val config: KubeConfig[F],
     val cachedExecToken: Option[CachedExecToken[F]],
     namespace: String
 )(implicit

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Creatable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Creatable.scala
@@ -17,7 +17,7 @@ import org.http4s.Method.*
 private[client] trait Creatable[F[_], Resource <: { def metadata: Option[ObjectMeta] }] {
   protected def httpClient: Client[F]
   implicit protected val F: Async[F]
-  protected def config: KubeConfig
+  protected def config: KubeConfig[F]
   protected def resourceUri: Uri
   protected def cachedExecToken: Option[CachedExecToken[F]]
   implicit protected def resourceEncoder: Encoder[Resource]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Deletable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Deletable.scala
@@ -13,7 +13,7 @@ import org.http4s.headers.`Content-Type`
 private[client] trait Deletable[F[_]] {
   protected def httpClient: Client[F]
   implicit protected val F: Async[F]
-  protected def config: KubeConfig
+  protected def config: KubeConfig[F]
   protected def cachedExecToken: Option[CachedExecToken[F]]
   protected def resourceUri: Uri
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Gettable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Gettable.scala
@@ -12,7 +12,7 @@ import org.http4s.Method._
 private[client] trait Gettable[F[_], Resource] {
   protected def httpClient: Client[F]
   implicit protected val F: Async[F]
-  protected def config: KubeConfig
+  protected def config: KubeConfig[F]
   protected def cachedExecToken: Option[CachedExecToken[F]]
   protected def resourceUri: Uri
   implicit protected def resourceDecoder: Decoder[Resource]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/GroupDeletable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/GroupDeletable.scala
@@ -11,7 +11,7 @@ import org.http4s.Method._
 private[client] trait GroupDeletable[F[_]] {
   protected def httpClient: Client[F]
   implicit protected val F: Async[F]
-  protected def config: KubeConfig
+  protected def config: KubeConfig[F]
   protected def cachedExecToken: Option[CachedExecToken[F]]
   protected def resourceUri: Uri
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Listable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Listable.scala
@@ -13,7 +13,7 @@ import org.http4s.Method.*
 private[client] trait Listable[F[_], Resource] {
   protected def httpClient: Client[F]
   implicit protected val F: Async[F]
-  protected def config: KubeConfig
+  protected def config: KubeConfig[F]
   protected def cachedExecToken: Option[CachedExecToken[F]]
   protected def resourceUri: Uri
   implicit protected def listDecoder: Decoder[Resource]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Proxy.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Proxy.scala
@@ -1,8 +1,9 @@
 package com.goyeau.kubernetes.client.operation
 
+import cats.syntax.all.*
 import cats.effect.Async
 import com.goyeau.kubernetes.client.KubeConfig
-import org.http4s._
+import org.http4s.*
 import org.http4s.client.Client
 import org.http4s.EntityDecoder
 import org.http4s.Uri.Path
@@ -11,7 +12,7 @@ import org.http4s.headers.`Content-Type`
 private[client] trait Proxy[F[_]] {
   protected def httpClient: Client[F]
   implicit protected val F: Async[F]
-  protected def config: KubeConfig
+  protected def config: KubeConfig[F]
   protected def resourceUri: Uri
 
   def proxy(
@@ -21,14 +22,19 @@ private[client] trait Proxy[F[_]] {
       contentType: `Content-Type` = `Content-Type`(MediaType.text.plain),
       data: Option[String] = None
   ): F[String] =
-    httpClient.expect[String](
-      Request(
-        method,
-        (config.server.resolve(resourceUri) / name / "proxy").addPath(path.toRelative.renderString),
-        headers = Headers(config.authorization.toList),
-        body = data.fold[EntityBody[F]](EmptyBody)(
-          implicitly[EntityEncoder[F, String]].withContentType(contentType).toEntity(_).body
-        )
-      )
-    )(EntityDecoder.text)
+    config.authorization
+      .fold(Headers.empty.pure[F])(_.map(authorization => Headers(authorization)))
+      .flatMap { headers =>
+        httpClient.expect[String](
+          Request(
+            method,
+            (config.server.resolve(resourceUri) / name / "proxy").addPath(path.toRelative.renderString),
+            headers = headers,
+            body = data.fold[EntityBody[F]](EmptyBody)(
+              implicitly[EntityEncoder[F, String]].withContentType(contentType).toEntity(_).body
+            )
+          )
+        )(EntityDecoder.text)
+      }
+
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Replaceable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Replaceable.scala
@@ -14,7 +14,7 @@ import org.http4s.Method._
 private[client] trait Replaceable[F[_], Resource <: { def metadata: Option[ObjectMeta] }] {
   protected def httpClient: Client[F]
   implicit protected val F: Async[F]
-  protected def config: KubeConfig
+  protected def config: KubeConfig[F]
   protected def cachedExecToken: Option[CachedExecToken[F]]
   protected def resourceUri: Uri
   implicit protected def resourceEncoder: Encoder[Resource]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Watchable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Watchable.scala
@@ -17,7 +17,7 @@ import org.typelevel.jawn.Facade
 private[client] trait Watchable[F[_], Resource] {
   protected def httpClient: Client[F]
   implicit protected val F: Async[F]
-  protected def config: KubeConfig
+  protected def config: KubeConfig[F]
   protected def cachedExecToken: Option[CachedExecToken[F]]
   protected def resourceUri: Uri
   protected def watchResourceUri: Uri = resourceUri

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
@@ -1,6 +1,6 @@
 package com.goyeau.kubernetes.client
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Applicative, FlatMap}
 import cats.effect.Resource
 import com.goyeau.kubernetes.client.util.CachedExecToken
@@ -12,11 +12,11 @@ import org.http4s.headers.Authorization
 package object operation {
   implicit private[client] class KubernetesRequestOps[F[_]: Applicative](request: Request[F]) {
     def withOptionalAuthorization(
-        auth: Option[Authorization],
+        auth: Option[F[Authorization]],
         cachedExecToken: Option[CachedExecToken[F]]
     ): F[Request[F]] =
       cachedExecToken match {
-        case None => auth.fold(request)(request.putHeaders(_)).pure[F]
+        case None => auth.fold(request.pure[F])(auth => auth.map(request.putHeaders(_)))
         case Some(cachedExecToken) =>
           cachedExecToken.get.map(token =>
             request.putHeaders(

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/SslContexts.scala
@@ -17,13 +17,13 @@ object SslContexts {
   private val KeyStoreSystemProperty           = "javax.net.ssl.keyStore"
   private val KeyStorePasswordSystemProperty   = "javax.net.ssl.keyStorePassword"
 
-  def fromConfig(config: KubeConfig): SSLContext = {
+  def fromConfig[F[_]](config: KubeConfig[F]): SSLContext = {
     val sslContext = SSLContext.getInstance("TLS")
     sslContext.init(keyManagers(config), trustManagers(config), new SecureRandom)
     sslContext
   }
 
-  private def keyManagers(config: KubeConfig) = {
+  private def keyManagers[F[_]](config: KubeConfig[F]) = {
     // Client certificate
     val certDataStream = config.clientCertData.map(data => new ByteArrayInputStream(Base64.getDecoder.decode(data)))
     val certFileStream = config.clientCertFile.map(new FileInputStream(_))
@@ -69,7 +69,7 @@ object SslContexts {
     keyStore
   }
 
-  private def trustManagers(config: KubeConfig) = {
+  private def trustManagers[F[_]](config: KubeConfig[F]) = {
     val certDataStream = config.caCertData.map(data => new ByteArrayInputStream(Base64.getDecoder.decode(data)))
     val certFileStream = config.caCertFile.map(new FileInputStream(_))
 


### PR DESCRIPTION
(this is the first of two PRs addressing the challenge described below, link to the second one is at the bottom)

A big thing that is happening in the k8s world is the release of Kubernetes 1.21, in which [BoundServiceAccountTokenVolume](https://github.com/kubernetes/enhancements/issues/542) got graduated to beta and is enabled by default. In particular, it will be enabled and used in AWS hosted k8s. 

Release notes: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.21 (see the first `Important` banner).

In short, this means that the auth token available within the cluster (in `/var/run/secrets/kubernetes.io/serviceaccount/token`) will now have an expiration time.

This means that we can no longer provide a token upon creation of the `KubeConfig` and expect it to work (it might expire in an hour or in a minute – we don't know).

This PR introduces a change to the way `KubeConfig` is created (when providing a token): the user will need to provide a token inside an `F[_]` and the client will evaluate it every time it needs a token. 

If the user wants to keep the previous behaviour, they can provide `theToken.pure[F]`.

Most of the files here have been changed solely because `KubeConfig` now has a type parameter: 
```scala
case class KubeConfig[F[_]] private (
    ...
    authorization: Option[F[Authorization]],
    ...
```

The second PR is built on top of this one and introduces more functionality related to this matter, as well as some improvements: https://github.com/joan38/kubernetes-client/pull/173

