### PR TITLE
add support for the pod log endpoint

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -7,12 +7,10 @@ import com.goyeau.kubernetes.client.api.*
 import com.goyeau.kubernetes.client.crd.{CrdContext, CustomResource, CustomResourceList}
 import com.goyeau.kubernetes.client.util.SslContexts
 import com.goyeau.kubernetes.client.util.cache.{AuthorizationParse, ExecToken}
-import com.goyeau.kubernetes.client.operation.*
 import io.circe.{Decoder, Encoder}
-import org.http4s.Request
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient, WSClient, WSRequest}
+import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient, WSClient}
 import org.typelevel.log4cats.Logger
 
 import java.net.http.HttpClient
@@ -63,24 +61,6 @@ class KubernetesClient[F[_]: Async: Logger](
       encoder: Encoder[CustomResource[A, B]],
       decoder: Decoder[CustomResource[A, B]]
   ) = new CustomResourcesApi[F, A, B](httpClient, config, authorization, context)
-
-  def customRequest(
-      request: Request[F]
-  ): F[Request[F]] =
-    Request[F](
-      method = request.method,
-      uri = config.server.resolve(request.uri),
-      httpVersion = request.httpVersion,
-      headers = request.headers,
-      body = request.body,
-      attributes = request.attributes
-    ).withOptionalAuthorization(authorization)
-
-  def customRequest(request: WSRequest): F[WSRequest] =
-    request
-      .copy(uri = config.server.resolve(request.uri))
-      .withOptionalAuthorization(authorization)
-
 }
 
 object KubernetesClient {

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -7,10 +7,12 @@ import com.goyeau.kubernetes.client.api.*
 import com.goyeau.kubernetes.client.crd.{CrdContext, CustomResource, CustomResourceList}
 import com.goyeau.kubernetes.client.util.SslContexts
 import com.goyeau.kubernetes.client.util.cache.{AuthorizationParse, ExecToken}
+import com.goyeau.kubernetes.client.operation.*
 import io.circe.{Decoder, Encoder}
+import org.http4s.Request
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient, WSClient}
+import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient, WSClient, WSRequest}
 import org.typelevel.log4cats.Logger
 
 import java.net.http.HttpClient
@@ -61,6 +63,24 @@ class KubernetesClient[F[_]: Async: Logger](
       encoder: Encoder[CustomResource[A, B]],
       decoder: Decoder[CustomResource[A, B]]
   ) = new CustomResourcesApi[F, A, B](httpClient, config, authorization, context)
+
+  def customRequest(
+      request: Request[F]
+  ): F[Request[F]] =
+    Request[F](
+      method = request.method,
+      uri = config.server.resolve(request.uri),
+      httpVersion = request.httpVersion,
+      headers = request.headers,
+      body = request.body,
+      attributes = request.attributes
+    ).withOptionalAuthorization(authorization)
+
+  def customRequest(request: WSRequest): F[WSRequest] =
+    request
+      .copy(uri = config.server.resolve(request.uri))
+      .withOptionalAuthorization(authorization)
+
 }
 
 object KubernetesClient {

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/PodsApi.scala
@@ -311,4 +311,94 @@ private[client] class NamespacedPodsApi[F[_]](
 
   private def convertToString(data: ByteVector) =
     new String(data.toArray, Charset.`UTF-8`.nioCharset)
+
+  /** @param podName
+    *   The pod for which to stream logs.
+    * @param container
+    *   The container for which to stream logs. Defaults to only container if there is one container in the pod.
+    * @param follow
+    *   Follow the log stream of the pod. Defaults to false.
+    * @param insecureSkipTLSVerifyBackend
+    *   indicates that the apiserver should not confirm the validity of the serving certificate of the backend it is
+    *   connecting to. This will make the HTTPS connection between the apiserver and the backend insecure. This means
+    *   the apiserver cannot verify the log data it is receiving came from the real kubelet. If the kubelet is
+    *   configured to verify the apiserver's TLS credentials, it does not mean the connection to the real kubelet is
+    *   vulnerable to a man in the middle attack (e.g. an attacker could not intercept the actual log data coming from
+    *   the real kubelet).
+    * @param limitBytes
+    *   If set, the number of bytes to read from the server before terminating the log output. This may not display a
+    *   complete final line of logging, and may return slightly more or slightly less than the specified limit.
+    * @param pretty
+    *   If 'true', then the output is pretty printed. Defaults to false.
+    * @param previous
+    *   Return previous terminated container logs. Defaults to false.
+    * @param sinceSeconds
+    *   A relative time in seconds before the current time from which to show logs. If this value precedes the time a
+    *   pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be
+    *   returned. Only one of sinceSeconds or sinceTime may be specified.
+    * @param tailLines
+    *   If set, the number of lines from the end of the logs to show. If not specified, logs are shown from the creation
+    *   of the container or sinceSeconds or sinceTime
+    * @param timestamps
+    *   If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output. Defaults to
+    *   false.
+    * @return
+    */
+  private def logRequest(
+      podName: String,
+      container: Option[String],
+      follow: Boolean,
+      insecureSkipTLSVerifyBackend: Boolean,
+      limitBytes: Option[Long],
+      pretty: Boolean,
+      previous: Boolean,
+      sinceSeconds: Option[Long],
+      tailLines: Option[Long],
+      timestamps: Boolean
+  ): F[Request[F]] = {
+    val uri = (config.server.resolve(resourceUri) / podName / "log")
+      .+??("container" -> container)
+      .+?("follow" -> follow.toString)
+      .+?("insecureSkipTLSVerifyBackend" -> insecureSkipTLSVerifyBackend.toString)
+      .+??("limitBytes" -> limitBytes.map(_.toString))
+      .+?("pretty" -> pretty.toString)
+      .+?("previous" -> previous.toString)
+      .+??("sinceSeconds" -> sinceSeconds.map(_.toString))
+      .+??("tailLines" -> tailLines.map(_.toString))
+      .+?("timestamps" -> timestamps.toString)
+
+    Request[F](method = Method.GET, uri = uri).withOptionalAuthorization(authorization)
+  }
+
+  def log(
+      podName: String,
+      container: Option[String] = None,
+      follow: Boolean = false,
+      insecureSkipTLSVerifyBackend: Boolean = false,
+      limitBytes: Option[Long] = None,
+      pretty: Boolean = false,
+      previous: Boolean = false,
+      sinceSeconds: Option[Long] = None,
+      tailLines: Option[Long] = None,
+      timestamps: Boolean = false
+  ): Stream[F, Response[F]] =
+    fs2.Stream
+      .eval(
+        logRequest(
+          podName,
+          container,
+          follow,
+          insecureSkipTLSVerifyBackend,
+          limitBytes,
+          pretty,
+          previous,
+          sinceSeconds,
+          tailLines,
+          timestamps
+        )
+      )
+      .flatMap { request =>
+        httpClient.stream(request)
+      }
+
 }


### PR DESCRIPTION
Adding support for the pod log endpoint.


~~Another minor addition here - two helper methods in the client:~~

 * ~~`def customRequest(request: Request[F]): F[Request[F]]` and~~
 * ~~`def customRequest(request: WSRequest): F[WSRequest]`~~

~~This should help us more easily use other k8s API endpoints that are not explicitly supported.
(I had to do some "hacking" in order to use the logs endpoint in our code, like defining an object inside the `com.goyeau.kubernetes.client` package in order to get access to `.withOptionalAuthorization` and some other things).~~