### PR TITLE
support for custom API requests

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/KubernetesClient.scala
@@ -7,10 +7,12 @@ import com.goyeau.kubernetes.client.api.*
 import com.goyeau.kubernetes.client.crd.{CrdContext, CustomResource, CustomResourceList}
 import com.goyeau.kubernetes.client.util.SslContexts
 import com.goyeau.kubernetes.client.util.cache.{AuthorizationParse, ExecToken}
+import com.goyeau.kubernetes.client.operation.*
 import io.circe.{Decoder, Encoder}
+import org.http4s.Request
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient, WSClient}
+import org.http4s.jdkhttpclient.{JdkHttpClient, JdkWSClient, WSClient, WSRequest}
 import org.typelevel.log4cats.Logger
 
 import java.net.http.HttpClient
@@ -61,6 +63,24 @@ class KubernetesClient[F[_]: Async: Logger](
       encoder: Encoder[CustomResource[A, B]],
       decoder: Decoder[CustomResource[A, B]]
   ) = new CustomResourcesApi[F, A, B](httpClient, config, authorization, context)
+
+  def customRequest(
+      request: Request[F]
+  ): F[Request[F]] =
+    Request[F](
+      method = request.method,
+      uri = config.server.resolve(request.uri),
+      httpVersion = request.httpVersion,
+      headers = request.headers,
+      body = request.body,
+      attributes = request.attributes
+    ).withOptionalAuthorization(authorization)
+
+  def customRequest(request: WSRequest): F[WSRequest] =
+    request
+      .copy(uri = config.server.resolve(request.uri))
+      .withOptionalAuthorization(authorization)
+
 }
 
 object KubernetesClient {


### PR DESCRIPTION
Adding two helper methods in the client:

 * `def customRequest(request: Request[F]): F[Request[F]]` and
 * `def customRequest(request: WSRequest): F[WSRequest]`

These methods update the provided request by setting the API hostname and adding the authorization.

This should help us more easily use other k8s API endpoints that are not explicitly supported by this library.

(Not having these, I had to do some "hacking" in order to use the logs endpoint in our code, like defining an object inside the `com.goyeau.kubernetes.client` package in order to get access to `.withOptionalAuthorization` and some other things).