### PR TITLE
Watch from resource version

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Watchable.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/Watchable.scala
@@ -25,8 +25,11 @@ private[client] trait Watchable[F[_], Resource] {
 
   implicit val parserFacade: Facade[Json] = new CirceSupportParser(None, false).facade
 
-  def watch(labels: Map[String, String] = Map.empty): Stream[F, Either[String, WatchEvent[Resource]]] = {
-    val uri = addLabels(labels, config.server.resolve(watchResourceUri))
+  def watch(
+      labels: Map[String, String] = Map.empty,
+      resourceVersion: Option[String] = None
+  ): Stream[F, Either[String, WatchEvent[Resource]]] = {
+    val uri = addLabels(labels, config.server.resolve(watchResourceUri)).+??("resourceVersion" -> resourceVersion)
     val req = Request[F](GET, uri.withQueryParam("watch", "1"))
       .withOptionalAuthorization(authorization)
     jsonStream(req).map(_.as[WatchEvent[Resource]].leftMap(_.getMessage))

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/WatchableTests.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/operation/WatchableTests.scala
@@ -55,20 +55,25 @@ trait WatchableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }]
 
   private def sendEvents(namespace: String, resourceName: String)(implicit client: KubernetesClient[F]) =
     for {
+      _ <- retry(
+        create(namespace, resourceName),
+        maxRetries = 30,
+        actionClue = Some(s"Creating $resourceName in $namespace ns")
+      )
       _      <- retry(update(namespace, resourceName), actionClue = Some(s"Updating $resourceName"))
       status <- deleteResource(namespace, resourceName)
       _ = assertEquals(status, Status.Ok, status.sanitizedReason)
     } yield ()
 
   private def create(namespace: String, resourceName: String)(implicit client: KubernetesClient[F]) =
-    retry(for {
+    for {
       ns <- client.namespaces.get(namespace)
       _ <- logger.info(
         s"creating in namespace: ${ns.metadata.flatMap(_.name).getOrElse("n/a/")}, status: ${ns.status.flatMap(_.phase)}"
       )
       status <- namespacedApi(namespace).create(sampleResource(resourceName, Map.empty))
       _ = assertEquals(status, Status.Created, status.sanitizedReason)
-    } yield ())
+    } yield ()
 
   private def watchEvents(
       expected: Map[String, Set[EventType]],
@@ -141,16 +146,13 @@ trait WatchableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }]
       val expectedEvents = Set[EventType](EventType.ADDED, EventType.MODIFIED, EventType.DELETED)
       val expected =
         if (watchIsNamespaced)
-          (defaultNamespace +: extraNamespace).map(_ -> expectedEvents).toMap
+          (defaultNamespace +: extraNamespace.toList).map(_ -> expectedEvents).toMap
         else
           Map(defaultNamespace -> expectedEvents)
 
       (
         watchEvents(expected, name, None),
-        F.sleep(100.millis) *>
-          create(defaultNamespace, name) *>
-          sendEvents(defaultNamespace, name) *>
-          sendToAnotherNamespace(name)
+        F.sleep(100.millis) *> sendEvents(defaultNamespace, name) *> sendToAnotherNamespace(name)
       ).parTupled
     }
   }
@@ -163,28 +165,24 @@ trait WatchableTests[F[_], Resource <: { def metadata: Option[ObjectMeta] }]
 
       (
         watchEvents(Map(defaultNamespace -> expected), name, Some(defaultNamespace)),
-        F.sleep(100.millis) *>
-          create(defaultNamespace, name) *>
-          sendEvents(defaultNamespace, name) *>
-          sendToAnotherNamespace(name)
+        F.sleep(100.millis) *> sendEvents(defaultNamespace, name) *> sendToAnotherNamespace(name)
       ).parTupled
     }
   }
 
   test(s"watch $resourceName events from a given resourceVersion") {
     usingMinikube { implicit client =>
-      val name     = s"${resourceName.toLowerCase}-watch-resource-version"
-      val expected = Set[EventType](EventType.MODIFIED, EventType.DELETED)
+      val bootstrapName = s"${resourceName.toLowerCase}-watch-resource-version-test-bootstrap"
+      val name          = s"${resourceName.toLowerCase}-watch-resource-version"
+      val expected      = Set[EventType](EventType.ADDED, EventType.MODIFIED, EventType.DELETED)
 
       for {
-        resourceVersion <- create(defaultNamespace, name)
-        resource        <- retry(getChecked(defaultNamespace, resourceName))
+        _        <- create(defaultNamespace, bootstrapName)
+        resource <- retry(getChecked(defaultNamespace, bootstrapName))
         resourceVersion = resource.metadata.flatMap(_.resourceVersion).get
         _ <- (
           watchEvents(Map(defaultNamespace -> expected), name, Some(defaultNamespace), Some(resourceVersion)),
-          F.sleep(100.millis) *>
-            sendEvents(defaultNamespace, name) *>
-            sendToAnotherNamespace(name)
+          F.sleep(100.millis) *> sendEvents(defaultNamespace, name) *> sendToAnotherNamespace(name)
         ).parTupled
       } yield ()
     }


### PR DESCRIPTION
Fixes https://github.com/joan38/kubernetes-client/issues/138

@timbertson I have taken the liberty of simplifying the diff and correcting the tests in `WatchableTests`, were they ever passing?

I need this exact pattern of retrieving the list and then watching from a revision @joan38, so I've done this so that this can maybe make the cut before the upcoming release? 🤞 

Note that in the newer v1.27 beta API there is support for streaming lists: https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists which would be even better 