### PR TITLE
bugfix: refresh before token expires, not after

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -35,7 +35,7 @@ class KubernetesClientModule(val crossScalaVersion: String)
   )
 
   override def ivyDeps =
-    super.ivyDeps() ++ http4s ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging
+    super.ivyDeps() ++ http4s ++ circe ++ circeYaml ++ bouncycastle ++ collectionCompat ++ logging ++ java8compat
   override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++
     (if (isScala3(scalaVersion())) Agg.empty else Agg(ivy"org.typelevel:::kind-projector:0.13.2"))
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/cache/AuthorizationCache.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/cache/AuthorizationCache.scala
@@ -5,7 +5,7 @@ import cats.effect.Async
 import cats.syntax.all.*
 import org.http4s.headers.Authorization
 import org.typelevel.log4cats.Logger
-import scala.jdk.DurationConverters.*
+import scala.compat.java8.DurationConverters.*
 
 import scala.concurrent.duration.*
 

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/cache/AuthorizationCache.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/cache/AuthorizationCache.scala
@@ -38,8 +38,8 @@ object AuthorizationCache {
               case Some(cached) =>
                 F.realTimeInstant
                   .flatMap { now =>
-                    val shouldRenew =
-                      cached.expirationTimestamp.exists(_.isBefore(now.minusSeconds(refreshBeforeExpiration.toSeconds)))
+                    val minExpiry   = now.plusSeconds(refreshBeforeExpiration.toSeconds)
+                    val shouldRenew = cached.expirationTimestamp.exists(_.isBefore(minExpiry))
                     if (shouldRenew)
                       getAndCacheToken.flatMap {
                         case Some(token) => token.pure[F]

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/util/cache/AuthorizationCache.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/util/cache/AuthorizationCache.scala
@@ -5,6 +5,7 @@ import cats.effect.Async
 import cats.syntax.all.*
 import org.http4s.headers.Authorization
 import org.typelevel.log4cats.Logger
+import scala.jdk.DurationConverters.*
 
 import scala.concurrent.duration.*
 
@@ -38,7 +39,7 @@ object AuthorizationCache {
               case Some(cached) =>
                 F.realTimeInstant
                   .flatMap { now =>
-                    val minExpiry   = now.plusSeconds(refreshBeforeExpiration.toSeconds)
+                    val minExpiry   = now.plus(refreshBeforeExpiration.toJava)
                     val shouldRenew = cached.expirationTimestamp.exists(_.isBefore(minExpiry))
                     if (shouldRenew)
                       getAndCacheToken.flatMap {

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -31,5 +31,7 @@ object Dependencies {
 
   lazy val logback = Agg(ivy"ch.qos.logback:logback-classic:1.4.11")
 
+  lazy val java8compat = Agg(ivy"org.scala-lang.modules::scala-java8-compat:1.0.2")
+
   lazy val tests = Agg(ivy"org.scalameta::munit:0.7.29")
 }


### PR DESCRIPTION
If you set `refreshBeforeExpiration` to 1 minute, the current code refreshes the token only _after_ the token has expired for at least a minute. Time maths are hard, I had to add the test to actually verify my hunch 😆 