### PR TITLE
better raw requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,10 +294,6 @@ A specific test:
 
 [minikube](https://minikube.sigs.k8s.io/docs/) has to be installed and running.
 
-```shell
-./mill kubernetes-client[2.13.10].compile
-```
-
 ### Before opening a PR:
 
 Check and fix formatting:

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/RawApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/RawApi.scala
@@ -1,0 +1,44 @@
+package com.goyeau.kubernetes.client.api
+
+import cats.effect.syntax.all.*
+import cats.effect.{Async, Resource}
+import com.goyeau.kubernetes.client.KubeConfig
+import com.goyeau.kubernetes.client.operation.*
+import org.http4s.client.Client
+import org.http4s.headers.Authorization
+import org.http4s.jdkhttpclient.{WSClient, WSConnectionHighLevel, WSRequest}
+import org.http4s.{Request, Response}
+
+private[client] class RawApi[F[_]](
+    httpClient: Client[F],
+    wsClient: WSClient[F],
+    config: KubeConfig[F],
+    authorization: Option[F[Authorization]]
+)(implicit F: Async[F]) {
+
+  def runRequest(
+      request: Request[F]
+  ): Resource[F, Response[F]] =
+    Request[F](
+      method = request.method,
+      uri = config.server.resolve(request.uri),
+      httpVersion = request.httpVersion,
+      headers = request.headers,
+      body = request.body,
+      attributes = request.attributes
+    ).withOptionalAuthorization(authorization)
+      .toResource
+      .flatMap(httpClient.run)
+
+  def connectWS(
+      request: WSRequest
+  ): Resource[F, WSConnectionHighLevel[F]] =
+    request
+      .copy(uri = config.server.resolve(request.uri))
+      .withOptionalAuthorization(authorization)
+      .toResource
+      .flatMap { request =>
+        wsClient.connectHighLevel(request)
+      }
+
+}

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/RawApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/RawApiTest.scala
@@ -1,0 +1,70 @@
+package com.goyeau.kubernetes.client.api
+
+import cats.syntax.all.*
+import cats.effect.unsafe.implicits.global
+import cats.effect.{Async, IO}
+import com.goyeau.kubernetes.client.KubernetesClient
+import com.goyeau.kubernetes.client.Utils.retry
+import com.goyeau.kubernetes.client.api.ExecStream.{StdErr, StdOut}
+import com.goyeau.kubernetes.client.operation.*
+import fs2.io.file.{Files, Path}
+import fs2.{text, Stream}
+import io.k8s.api.core.v1.*
+import io.k8s.apimachinery.pkg.apis.meta.v1
+import io.k8s.apimachinery.pkg.apis.meta.v1.{ListMeta, ObjectMeta}
+import munit.FunSuite
+import org.http4s.{Request, Status, Uri}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import java.nio.file.Files as JFiles
+import scala.util.Random
+import org.http4s.implicits.*
+import org.http4s.jdkhttpclient.WSConnectionHighLevel
+
+class RawApiTest extends FunSuite with MinikubeClientProvider[IO] with ContextProvider {
+
+  implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+  // MinikubeClientProvider will create a namespace with this name, even though it's not used in this test
+  override lazy val resourceName: String = "raw-api-tests"
+
+  test("list nodes with raw requests") {
+    kubernetesClient
+      .use { implicit client =>
+        for {
+          response <- client.raw
+            .runRequest(
+              Request[IO](
+                uri = uri"/api" / "v1" / "nodes"
+              )
+            )
+            .use { response =>
+              response.bodyText.foldMonoid.compile.lastOrError.map { body =>
+                (response.status, body)
+              }
+            }
+          (status, body) = response
+          _ = assertEquals(
+            status,
+            Status.Ok,
+            s"non 200 status for get nodes raw request"
+          )
+          nodeList <- F.fromEither(
+            io.circe.parser.decode[NodeList](body)
+          )
+          _ = assert(
+            nodeList.kind.contains("NodeList"),
+            "wrong .kind in the response"
+          )
+          _ = assert(
+            nodeList.items.nonEmpty,
+            "empty node list"
+          )
+        } yield ()
+      }
+      .unsafeRunSync()
+  }
+
+}


### PR DESCRIPTION
A followup to https://github.com/joan38/kubernetes-client/pull/246 - the solution there was incomplete (and, admittedly, not very well thought through).

For example, if the underlying http client happens to be configured with an SSL context - the user will be stuck, since we only prepare the request for them, but they still don't have access to the http client to run it with.

Here, I introduced a new "module" to the kubernetes client: `RawApi` (`client.raw`) which exposes two methods:

* `runRequest`
* `connectWS`

Those methods will prepare and execute the requests, but leave the handling of the responses to the user's discretion.