### PR TITLE
Update K8s to 1.31.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -25,119 +25,41 @@ jobs:
       - name: Style checks
         run: ./mill __.checkStyle + __.docJar
 
-  integration-kubernetes-v1-25:
-    runs-on: ubuntu-latest
+  integration-kubernetes:
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      matrix:
+        kubernetes-version:
+          - v1.32.1
+          - v1.31.5
+          - v1.30.9
+          - v1.29.13
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Minikube and start Kubernetes
         uses: medyagh/setup-minikube@v0.0.8
         with:
-          minikube-version: 1.28.0
-          kubernetes-version: v1.25.3
+          minikube-version: 1.35.0
+          kubernetes-version: ${{ matrix.kubernetes-version }}
       - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
           java-version: 11.0.x
           distribution: zulu
-      - name: Test against Kubernetes v1.25
-        run: ./mill __[3.3.4].test
-
-  integration-kubernetes-v1-24:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Minikube and start Kubernetes
-        uses: medyagh/setup-minikube@v0.0.8
-        with:
-          minikube-version: 1.28.0
-          kubernetes-version: v1.24.7
-      - name: Setup Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11.0.x
-          distribution: zulu
-      - name: Test against Kubernetes v1.24
-        run: ./mill __[3.3.4].test
-
-  integration-kubernetes-v1-23:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Minikube and start Kubernetes
-        uses: medyagh/setup-minikube@v0.0.8
-        with:
-          minikube-version: 1.28.0
-          kubernetes-version: v1.23.13
-      - name: Setup Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11.0.x
-          distribution: zulu
-      - name: Test against Kubernetes v1.23
-        run: ./mill __[3.3.4].test
-
-  integration-kubernetes-v1-22:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Minikube and start Kubernetes
-        uses: medyagh/setup-minikube@v0.0.8
-        with:
-          minikube-version: 1.28.0
-          kubernetes-version: v1.22.15
-      - name: Setup Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11.0.x
-          distribution: zulu
-      - name: Test against Kubernetes v1.22
-        run: ./mill __[3.3.4].test
-
-  integration-kubernetes-v1-21:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Minikube and start Kubernetes
-        uses: medyagh/setup-minikube@v0.0.8
-        with:
-          minikube-version: 1.28.0
-          kubernetes-version: v1.21.14
-      - name: Setup Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11.0.x
-          distribution: zulu
-      - name: Test against Kubernetes v1.21
+      - name: Test against Kubernetes ${{ matrix.kubernetes-version }}
         run: ./mill __[3.3.4].test
 
   publish:
     needs:
       - checks
-      - integration-kubernetes-v1-25
-      - integration-kubernetes-v1-24
-      - integration-kubernetes-v1-23
-      - integration-kubernetes-v1-22
-      - integration-kubernetes-v1-21
+      - integration-tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Pull all history with tags for correct versionning
+      - name: Pull all history with tags for correct versioning
         run: git fetch --prune --unshallow
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
   publish:
     needs:
       - checks
-      - integration-tests
+      - integration-kubernetes
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Minikube and start Kubernetes
-        uses: medyagh/setup-minikube@v0.0.8
+        uses: medyagh/setup-minikube@v0.0.19
         with:
           minikube-version: 1.35.0
           kubernetes-version: ${{ matrix.kubernetes-version }}

--- a/build.sc
+++ b/build.sc
@@ -22,6 +22,7 @@ trait KubernetesClientModule
     with StyleModule
     with GitVersionedPublishModule
     with SwaggerModelGenerator {
+  def kubernetesSwagger     = downloadedKubernetesSwagger
   lazy val jvmVersion       = "11"
   override def javacOptions = super.javacOptions() ++ Seq("-source", jvmVersion, "-target", jvmVersion)
   override def scalacOptions = super.scalacOptions() ++ ScalacOptions.tokensForVersion(
@@ -48,4 +49,14 @@ trait KubernetesClientModule
     versionControl = VersionControl.github("joan38", "kubernetes-client"),
     developers = Seq(Developer("joan38", "Joan Goyeau", "https://github.com/joan38"))
   )
+}
+
+def kubernetesVersion: T[String] = T("1.31.1")
+
+def downloadedKubernetesSwagger: T[String] = T {
+  requests
+    .get(
+      s"https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v${kubernetesVersion()}/api/openapi-spec/swagger.json"
+    )
+    .text()
 }

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PersistentVolumeClaimsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PersistentVolumeClaimsApiTest.scala
@@ -8,7 +8,7 @@ import io.k8s.api.core.v1.{
   PersistentVolumeClaim,
   PersistentVolumeClaimList,
   PersistentVolumeClaimSpec,
-  ResourceRequirements
+  VolumeResourceRequirements
 }
 import io.k8s.apimachinery.pkg.api.resource.Quantity
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
@@ -41,7 +41,7 @@ class PersistentVolumeClaimsApiTest
       metadata = ObjectMeta(name = resourceName.some, labels = labels.some).some,
       spec = PersistentVolumeClaimSpec(
         accessModes = Seq("ReadWriteOnce").some,
-        resources = ResourceRequirements(
+        resources = VolumeResourceRequirements(
           requests = Map("storage" -> Quantity("1Mi")).some
         ).some,
         storageClassName = "local-path".some

--- a/project/SwaggerModelGenerator.sc
+++ b/project/SwaggerModelGenerator.sc
@@ -12,18 +12,10 @@ import io.circe.generic.auto._
 import io.circe.parser._
 import os._
 
-def kubernetesVersion: T[String] = T("1.31.1")
-
-def kubernetesSwagger: T[String] = T {
-  requests
-    .get(
-      s"https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v${kubernetesVersion()}/api/openapi-spec/swagger.json"
-    )
-    .text()
-}
-
 trait SwaggerModelGenerator extends JavaModule {
   import SwaggerModelGenerator._
+
+  def kubernetesSwagger: T[String]
 
   override def generatedSources = T {
     super.generatedSources() ++


### PR DESCRIPTION
- Use Github Action matrix to test on multiple K8s versions
- Update K8s swagger to latest version
- Download swagger with Mill and delete swagger in resources.
- Fix `PodsApiTest` to correctly check for readiness.