### PR TITLE
Upgrade http4s-jdk and allow additional clients to be passed in

### DIFF
--- a/kubernetes-client/src/com/goyeau/kubernetes/client/api/RawApi.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/api/RawApi.scala
@@ -6,7 +6,7 @@ import com.goyeau.kubernetes.client.KubeConfig
 import com.goyeau.kubernetes.client.operation.*
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.{WSClient, WSConnectionHighLevel, WSRequest}
+import org.http4s.client.websocket.*
 import org.http4s.{Request, Response}
 
 private[client] class RawApi[F[_]](
@@ -32,13 +32,9 @@ private[client] class RawApi[F[_]](
 
   def connectWS(
       request: WSRequest
-  ): Resource[F, WSConnectionHighLevel[F]] =
-    request
-      .copy(uri = config.server.resolve(request.uri))
-      .withOptionalAuthorization(authorization)
-      .toResource
-      .flatMap { request =>
-        wsClient.connectHighLevel(request)
-      }
-
+  ): Resource[F, WSConnectionHighLevel[F]] =  {
+    Resource.eval(request.withUri(config.server.resolve(request.uri)).withOptionalAuthorization(authorization)).flatMap { req =>
+      wsClient.connectHighLevel(req)
+    }
+  }
 }

--- a/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
+++ b/kubernetes-client/src/com/goyeau/kubernetes/client/operation/package.scala
@@ -5,7 +5,7 @@ import cats.syntax.all.*
 import cats.{Applicative, FlatMap}
 import org.http4s.client.Client
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.WSRequest
+import org.http4s.client.websocket.*
 import org.http4s.{EntityDecoder, Request, Response}
 
 package object operation {
@@ -22,7 +22,7 @@ package object operation {
     def withOptionalAuthorization(authorization: Option[F[Authorization]]): F[WSRequest] =
       authorization.fold(request.pure[F]) { authorization =>
         authorization.map { auth =>
-          request.copy(headers = request.headers.put(auth))
+          request.withHeaders(request.headers.put(auth))
         }
       }
   }

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ConfigMapsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ConfigMapsApiTest.scala
@@ -8,6 +8,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.{ConfigMap, ConfigMapList}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
+import fs2.io.file.Files
 
 class ConfigMapsApiTest
     extends FunSuite
@@ -21,6 +22,7 @@ class ConfigMapsApiTest
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit override lazy val G: Files[IO]       = Files.forIO
   override lazy val resourceName: String        = classOf[ConfigMap].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]): ConfigMapsApi[IO] = client.configMaps

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CronJobsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CronJobsApiTest.scala
@@ -10,6 +10,7 @@ import io.k8s.api.batch.v1.{CronJob, CronJobList, CronJobSpec, JobSpec, JobTempl
 import io.k8s.api.core.v1.*
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
+import fs2.io.file.Files
 
 class CronJobsApiTest
     extends FunSuite
@@ -24,6 +25,7 @@ class CronJobsApiTest
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit override lazy val G: Files[IO]       = Files.forIO
   override lazy val resourceName: String        = classOf[CronJob].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]): CronJobsApi[IO] = client.cronJobs

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourceDefinitionsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourceDefinitionsApiTest.scala
@@ -13,6 +13,7 @@ import munit.Assertions.*
 import org.http4s.Status
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import fs2.io.file.Files
 
 class CustomResourceDefinitionsApiTest
     extends FunSuite
@@ -26,6 +27,7 @@ class CustomResourceDefinitionsApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[CustomResourceDefinition].getSimpleName
   override val resourceIsNamespaced             = false

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourcesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/CustomResourcesApiTest.scala
@@ -14,6 +14,7 @@ import io.circe.generic.semiauto.*
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
 import org.http4s.Status
+import fs2.io.file.Files
 
 case class CronTab(cronSpec: String, image: String, replicas: Int)
 object CronTab {
@@ -42,6 +43,7 @@ class CustomResourcesApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[CronTab].getSimpleName
   val kind                                      = classOf[CronTab].getSimpleName

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/DeploymentsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/DeploymentsApiTest.scala
@@ -9,6 +9,7 @@ import io.k8s.api.apps.v1.*
 import io.k8s.api.core.v1.*
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}
 import munit.FunSuite
+import fs2.io.file.Files
 
 class DeploymentsApiTest
     extends FunSuite
@@ -22,6 +23,7 @@ class DeploymentsApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[Deployment].getSimpleName
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/HorizontalPodAutoscalersApiTest.scala
@@ -13,6 +13,7 @@ import io.k8s.api.autoscaling.v1.{
 }
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
+import fs2.io.file.Files
 
 class HorizontalPodAutoscalersApiTest
     extends FunSuite
@@ -25,6 +26,7 @@ class HorizontalPodAutoscalersApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[HorizontalPodAutoscaler].getSimpleName
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/IngressesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/IngressesApiTest.scala
@@ -8,6 +8,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.networking.v1.{Ingress, IngressList, IngressRule, IngressSpec}
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
+import fs2.io.file.Files
 
 class IngressesApiTest
     extends FunSuite
@@ -21,6 +22,7 @@ class IngressesApiTest
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit override lazy val G: Files[IO]       = Files.forIO
   override lazy val resourceName: String        = classOf[Ingress].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]): IngressessApi[IO] = client.ingresses

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/JobsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/JobsApiTest.scala
@@ -10,6 +10,7 @@ import io.k8s.api.batch.v1.{Job, JobList, JobSpec}
 import io.k8s.api.core.v1.*
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
+import fs2.io.file.Files
 
 class JobsApiTest
     extends FunSuite
@@ -23,6 +24,7 @@ class JobsApiTest
     with ContextProvider {
 
   implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName: String        = classOf[Job].getSimpleName
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/LeasesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/LeasesApiTest.scala
@@ -8,6 +8,7 @@ import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import fs2.io.file.Files
 
 class LeasesApiTest
     extends FunSuite
@@ -21,6 +22,7 @@ class LeasesApiTest
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit override lazy val G: Files[IO]       = Files.forIO
   override lazy val resourceName: String        = classOf[Lease].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]): LeasesApi[IO] = client.leases

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/NamespacesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/NamespacesApiTest.scala
@@ -13,11 +13,13 @@ import org.http4s.Status
 import org.http4s.client.UnexpectedStatus
 import munit.Assertions.*
 import munit.FunSuite
+import fs2.io.file.Files
 
 class NamespacesApiTest extends FunSuite with MinikubeClientProvider[IO] with ContextProvider {
   import NamespacesApiTest.*
 
   implicit lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   lazy val resourceName: String        = classOf[Namespace].getSimpleName
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/NodesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/NodesApiTest.scala
@@ -8,9 +8,12 @@ import io.k8s.api.core.v1.Node
 import munit.FunSuite
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import fs2.io.file.Files
 
 class NodesApiTest extends FunSuite with ContextProvider with MinikubeClientProvider[IO] {
   implicit lazy val F: Async[IO]                               = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
+
   implicit lazy val logger: Logger[IO]                         = Slf4jLogger.getLogger[IO]
   lazy val resourceName: String                                = classOf[Node].getSimpleName
   def api(implicit client: KubernetesClient[IO]): NodesApi[IO] = client.nodes

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PersistentVolumeClaimsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PersistentVolumeClaimsApiTest.scala
@@ -15,6 +15,7 @@ import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import fs2.io.file.Files
 
 class PersistentVolumeClaimsApiTest
     extends FunSuite
@@ -27,6 +28,7 @@ class PersistentVolumeClaimsApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[PersistentVolumeClaim].getSimpleName
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PodsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/PodsApiTest.scala
@@ -33,6 +33,7 @@ class PodsApiTest
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit override lazy val G: Files[IO]       = Files.forIO
   override lazy val resourceName: String        = classOf[Pod].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]): PodsApi[IO] = client.pods

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/RawApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/RawApiTest.scala
@@ -10,10 +10,12 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import org.http4s.implicits.*
+import fs2.io.file.Files
 
 class RawApiTest extends FunSuite with MinikubeClientProvider[IO] with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
   // MinikubeClientProvider will create a namespace with this name, even though it's not used in this test

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ReplicaSetsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ReplicaSetsApiTest.scala
@@ -9,6 +9,7 @@ import io.k8s.api.apps.v1.*
 import io.k8s.api.core.v1.*
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}
 import munit.FunSuite
+import fs2.io.file.Files
 
 class ReplicaSetsApiTest
     extends FunSuite
@@ -23,6 +24,7 @@ class ReplicaSetsApiTest
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit override lazy val G: Files[IO]       = Files.forIO
   override lazy val resourceName: String        = classOf[ReplicaSet].getSimpleName
 
   override def api(implicit client: KubernetesClient[IO]): ReplicaSetsApi[IO] = client.replicaSets

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/SecretsApiTest.scala
@@ -11,6 +11,7 @@ import java.util.Base64
 import munit.FunSuite
 import org.http4s.Status
 import scala.collection.compat.*
+import fs2.io.file.Files
 
 class SecretsApiTest
     extends FunSuite
@@ -23,6 +24,7 @@ class SecretsApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[Secret].getSimpleName
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServiceAccountsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServiceAccountsApiTest.scala
@@ -8,6 +8,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.k8s.api.core.v1.*
 import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
+import fs2.io.file.Files
 
 class ServiceAccountsApiTest
     extends FunSuite
@@ -20,6 +21,7 @@ class ServiceAccountsApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[ServiceAccount].getSimpleName
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServicesApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/ServicesApiTest.scala
@@ -8,6 +8,7 @@ import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 import munit.FunSuite
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import fs2.io.file.Files
 
 class ServicesApiTest
     extends FunSuite
@@ -20,6 +21,7 @@ class ServicesApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[Service].getSimpleName
 

--- a/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/StatefulSetsApiTest.scala
+++ b/kubernetes-client/test/src/com/goyeau/kubernetes/client/api/StatefulSetsApiTest.scala
@@ -9,6 +9,7 @@ import io.k8s.api.apps.v1.*
 import io.k8s.api.core.v1.*
 import io.k8s.apimachinery.pkg.apis.meta.v1.{LabelSelector, ObjectMeta}
 import munit.FunSuite
+import fs2.io.file.Files
 
 class StatefulSetsApiTest
     extends FunSuite
@@ -22,6 +23,7 @@ class StatefulSetsApiTest
     with ContextProvider {
 
   implicit override lazy val F: Async[IO]       = IO.asyncForIO
+  implicit override lazy val G: Files[IO]       = Files.forIO
   implicit override lazy val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   override lazy val resourceName: String        = classOf[StatefulSet].getSimpleName
 

--- a/project/Dependencies.sc
+++ b/project/Dependencies.sc
@@ -10,12 +10,12 @@ lazy val circe = {
   )
 }
 
+val http4sVersion = "0.23.30"
 lazy val http4s = {
-  val version          = "0.23.30"
-  val jdkClientVersion = "0.5.0"
+  val jdkClientVersion = "0.10.0"
   Agg(
-    ivy"org.http4s::http4s-dsl:$version",
-    ivy"org.http4s::http4s-circe:$version",
+    ivy"org.http4s::http4s-dsl:$http4sVersion",
+    ivy"org.http4s::http4s-circe:$http4sVersion",
     ivy"org.http4s::http4s-jdk-http-client:$jdkClientVersion"
   )
 }
@@ -32,4 +32,7 @@ lazy val logback = Agg(ivy"ch.qos.logback:logback-classic:1.5.18")
 
 lazy val java8compat = Agg(ivy"org.scala-lang.modules::scala-java8-compat:1.0.2")
 
-lazy val tests = Agg(ivy"org.scalameta::munit:1.1.1")
+lazy val tests = Agg(
+  ivy"org.scalameta::munit:1.1.1",
+  ivy"org.http4s::http4s-ember-client:${http4sVersion}"
+)


### PR DESCRIPTION
- Upgrade http4s-jdk library; it was quite old
- Allow clients to pass in any http4s Client implementation.  Note that this will only be used for non Web Socket requests, but given that the majority of the API does not use web sockets, I think this is an ok compromise to make progress while we await additional implementations.